### PR TITLE
Parametric mos and contact generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdkprims"
+version = "0.1.0"
+dependencies = [
+ "derive_builder 0.11.1",
+ "layout21",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "pest"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
   "edatool",
   "fanout",
+  "pdkprims",
   "magic_vlsi",
   "micro_hdl",
   "micro_hdl/micro_hdl_derive",

--- a/pdkprims/Cargo.toml
+++ b/pdkprims/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pdkprims"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+layout21 = { path = "../deps/Layout21/layout21" }
+toml = "0.5"
+thiserror = "1.0"
+derive_builder = "0.11"
+
+[features]
+sky130 = []
+default = ["sky130"]

--- a/pdkprims/src/config.rs
+++ b/pdkprims/src/config.rs
@@ -1,0 +1,195 @@
+use layout21::raw::Layer;
+use layout21::raw::LayerPurpose;
+use layout21::raw::Layers;
+use layout21::raw::LayoutResult;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+pub use layout21::raw::Int;
+
+/// The type to use for nonnegative values.
+/// Defaults to the same as [`Int`] for now.
+pub type Uint = isize;
+
+pub use layout21::raw::Units;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+pub struct ContactStack {
+    pub layers: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct TechConfig {
+    pub grid: Int,
+    pub tech: String,
+    pub gamma: f64,
+    pub beta: f64,
+    pub units: Units,
+    layers: HashMap<String, LayerConfig>,
+    spacing: Vec<SpacingConfig>,
+    stacks: HashMap<String, ContactStack>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+pub struct SpacingConfig {
+    pub from: String,
+    pub to: String,
+    pub dist: Int,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+pub struct Enclosure {
+    pub layer: String,
+    pub enclosure: Int,
+    pub one_side: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+pub struct Extension {
+    pub layer: String,
+    pub extend: Int,
+}
+
+#[derive(Debug, Default, Clone, Eq, PartialEq, Hash, Deserialize, Serialize)]
+pub struct LayerConfig {
+    pub desc: String,
+    pub width: Int,
+    pub space: Int,
+    pub area: Int,
+    #[serde(default)]
+    pub enclosures: Vec<Enclosure>,
+    #[serde(default)]
+    pub extensions: Vec<Extension>,
+    pub layernum: i16,
+    #[serde(default)]
+    pub purposes: Vec<(LayerPurpose, i16)>,
+}
+
+impl TechConfig {
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, Box<dyn std::error::Error>> {
+        let txt = std::fs::read_to_string(path)?;
+        Self::from_toml(&txt)
+    }
+
+    pub fn from_toml(s: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(toml::from_str(s)?)
+    }
+
+    pub fn layer(&self, l: &str) -> &LayerConfig {
+        self.layers.get(l).unwrap()
+    }
+
+    pub fn space(&self, from: &str, to: &str) -> Int {
+        self.spacing
+            .iter()
+            .find(|s| (s.from == from && s.to == to) || (s.to == from && s.from == to))
+            .take()
+            .map(|s| s.dist)
+            .unwrap_or_default()
+    }
+
+    pub fn scale_pmos(&self, nmos_width: Int) -> Int {
+        let pmos_width = (nmos_width as f64 * self.beta) / (self.grid as f64);
+        (pmos_width.round() as Int) * self.grid
+    }
+
+    pub fn stack(&self, stack: &str) -> &ContactStack {
+        self.stacks.get(stack).unwrap()
+    }
+
+    pub fn get_layers(&self) -> LayoutResult<Layers> {
+        let mut layers = Layers::default();
+        for (name, cfg) in self.layers.iter() {
+            let mut l = Layer::new(cfg.layernum, name);
+            for (p, i) in cfg.purposes.iter() {
+                l.add_purpose(*i, p.clone())?;
+            }
+            layers.add(l);
+        }
+        Ok(layers)
+    }
+}
+
+impl LayerConfig {
+    pub fn extension(&self, l: &str) -> Int {
+        self.extensions
+            .iter()
+            .find(|ext| ext.layer == l)
+            .take()
+            .map(|ext| ext.extend)
+            .unwrap_or_default()
+    }
+
+    fn enclosure_inner(&self, l: &str, one_sided: bool) -> Int {
+        let x = self
+            .enclosures
+            .iter()
+            .filter(|enc| enc.layer == l)
+            .collect::<Vec<_>>();
+
+        if one_sided {
+            x.into_iter().map(|x| x.enclosure).max().unwrap_or_default()
+        } else {
+            x.into_iter()
+                .filter(|x| !x.one_side)
+                .map(|x| x.enclosure)
+                .max()
+                .unwrap_or_default()
+        }
+    }
+
+    pub fn enclosure(&self, l: &str) -> Int {
+        self.enclosure_inner(l, false)
+    }
+
+    pub fn one_side_enclosure(&self, l: &str) -> Int {
+        self.enclosure_inner(l, true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_sky130_design_rules() -> Result<(), Box<dyn std::error::Error>> {
+        let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        p.push("../tech/sky130/drc_config.toml");
+        let tc = TechConfig::load(p)?;
+        let _layers = tc.get_layers()?;
+
+        println!("loaded config {:?}", tc);
+
+        assert_eq!(&tc.tech, "sky130A");
+        assert_eq!(tc.layer("poly").extension("ndiff"), 130);
+        assert_eq!(tc.layer("poly").extension("pdiff"), 130);
+
+        assert_eq!(tc.layer("poly").extension("pdiff"), 130);
+
+        assert_eq!(tc.layer("licon").enclosure("poly"), 50);
+        assert_eq!(tc.layer("licon").one_side_enclosure("poly"), 80);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_serialize_layer() -> Result<(), Box<dyn std::error::Error>> {
+        let layer = LayerConfig {
+            desc: "test layer".into(),
+            width: 200,
+            space: 300,
+            area: 0,
+            layernum: 67,
+            purposes: vec![(LayerPurpose::Drawing, 20), (LayerPurpose::Label, 44)],
+            enclosures: vec![],
+            extensions: vec![],
+        };
+
+        let res = toml::to_string(&layer)?;
+        println!("{}", res);
+
+        Ok(())
+    }
+}

--- a/pdkprims/src/config.rs
+++ b/pdkprims/src/config.rs
@@ -148,7 +148,7 @@ impl LayerConfig {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "sky130"))]
 mod tests {
     use super::*;
     use std::path::PathBuf;
@@ -163,10 +163,10 @@ mod tests {
         println!("loaded config {:?}", tc);
 
         assert_eq!(&tc.tech, "sky130A");
-        assert_eq!(tc.layer("poly").extension("ndiff"), 130);
-        assert_eq!(tc.layer("poly").extension("pdiff"), 130);
+        assert_eq!(tc.layer("poly").extension("diff"), 130);
+        assert_eq!(tc.layer("poly").extension("diff"), 130);
 
-        assert_eq!(tc.layer("poly").extension("pdiff"), 130);
+        assert_eq!(tc.layer("poly").extension("diff"), 130);
 
         assert_eq!(tc.layer("licon").enclosure("poly"), 50);
         assert_eq!(tc.layer("licon").one_side_enclosure("poly"), 80);

--- a/pdkprims/src/config.rs
+++ b/pdkprims/src/config.rs
@@ -95,7 +95,9 @@ impl TechConfig {
     }
 
     pub fn stack(&self, stack: &str) -> &ContactStack {
-        self.stacks.get(stack).unwrap()
+        self.stacks
+            .get(stack)
+            .expect(&format!("no such stack: {}", stack))
     }
 
     pub fn get_layers(&self) -> LayoutResult<Layers> {

--- a/pdkprims/src/config.rs
+++ b/pdkprims/src/config.rs
@@ -97,7 +97,7 @@ impl TechConfig {
     pub fn stack(&self, stack: &str) -> &ContactStack {
         self.stacks
             .get(stack)
-            .expect(&format!("no such stack: {}", stack))
+            .unwrap_or_else(|| panic!("no such stack: {}", stack))
     }
 
     pub fn get_layers(&self) -> LayoutResult<Layers> {

--- a/pdkprims/src/contact.rs
+++ b/pdkprims/src/contact.rs
@@ -57,10 +57,10 @@ impl ContactParams {
 impl Pdk {
     pub fn get_contact(&self, params: &ContactParams) -> Ref<Contact> {
         let mut map = self.contacts.write().unwrap();
-        if let Some(c) = map.get(&params) {
+        if let Some(c) = map.get(params) {
             c.clone()
         } else {
-            let c = self.draw_contact(&params);
+            let c = self.draw_contact(params);
             map.insert(params.to_owned(), c.clone());
             c
         }
@@ -121,8 +121,8 @@ impl Pdk {
         let x0 = 0;
         let y0 = 0;
 
-        let ctw = tc.layer(&ctlay_name).width;
-        let cts = tc.layer(&ctlay_name).space;
+        let ctw = tc.layer(ctlay_name).width;
+        let cts = tc.layer(ctlay_name).space;
         let ctbw = ctw * cols + cts * (cols - 1);
         let ctbh = ctw * rows + cts * (rows - 1);
 
@@ -164,7 +164,7 @@ impl Pdk {
             let lay = layers.keyname(lay_name).unwrap();
             let mut laybox = ct_bbox.clone();
             expand_box(&mut laybox, tc.layer(ctlay_name).enclosure(lay_name));
-            let ose = tc.layer(ctlay_name).one_side_enclosure(&lay_name);
+            let ose = tc.layer(ctlay_name).one_side_enclosure(lay_name);
 
             match params.dir {
                 CoarseDirection::Vertical => {
@@ -220,7 +220,7 @@ impl Pdk {
                 inner: Shape::Rect(well_box),
             });
         } else if params.stack == "polyc" {
-            let mut npc_box = ct_bbox.clone();
+            let mut npc_box = ct_bbox;
             expand_box(&mut npc_box, tc.layer("licon").enclosure("npc"));
             elems.push(Element {
                 net: None,
@@ -248,7 +248,7 @@ impl Pdk {
         let abs = Abstract {
             name: name.clone(),
             outline: Element {
-                net: Some(net_name.clone()),
+                net: Some(net_name),
                 layer: layers.keyname(&stack.layers[0]).unwrap(),
                 purpose: LayerPurpose::Drawing,
                 inner: Shape::Rect(outline),

--- a/pdkprims/src/contact.rs
+++ b/pdkprims/src/contact.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::sync::Arc;
 
 use layout21::raw::{
     Abstract, AbstractPort, BoundBox, BoundBoxTrait, Cell, Element, LayerKey, LayerPurpose, Layout,
@@ -8,6 +9,7 @@ use layout21::raw::{
 use layout21::utils::Ptr;
 use serde::{Deserialize, Serialize};
 
+use crate::Ref;
 use crate::config::Int;
 use crate::geometry::{expand_box, rect_from_bbox, CoarseDirection};
 use crate::{config::Uint, Pdk};
@@ -53,7 +55,7 @@ impl ContactParams {
 }
 
 impl Pdk {
-    pub fn get_contact(&self, params: &ContactParams) -> Contact {
+    pub fn get_contact(&self, params: &ContactParams) -> Ref<Contact> {
         let mut map = self.contacts.write().unwrap();
         if let Some(c) = map.get(&params) {
             c.clone()
@@ -69,7 +71,7 @@ impl Pdk {
         stack: impl Into<String>,
         layer: LayerKey,
         width: Int,
-    ) -> Option<Contact> {
+    ) -> Option<Ref<Contact>> {
         let mut low = 1;
         let mut high = 100;
         let mut result = None;
@@ -99,7 +101,7 @@ impl Pdk {
         result
     }
 
-    fn draw_contact(&self, params: &ContactParams) -> Contact {
+    fn draw_contact(&self, params: &ContactParams) -> Ref<Contact> {
         let rows = params.rows;
         let cols = params.cols;
 
@@ -263,11 +265,11 @@ impl Pdk {
 
         let cell = Ptr::new(cell);
 
-        Contact {
+        Arc::new(Contact {
             cell,
             rows: params.rows,
             cols: params.cols,
             bboxes: bbox_map,
-        }
+        })
     }
 }

--- a/pdkprims/src/contact.rs
+++ b/pdkprims/src/contact.rs
@@ -1,0 +1,96 @@
+use layout21::raw::{Cell, Element, LayerPurpose, Layout, Point, Rect, Shape};
+use layout21::utils::Ptr;
+
+use crate::config::Int;
+use crate::{config::Uint, Pdk};
+
+impl Pdk {
+    pub fn get_contact(&self, stack: impl Into<String>, rows: Uint, cols: Uint) -> Ptr<Cell> {
+        assert!(rows > 0);
+        assert!(cols > 0);
+        let tc = self.config.read().unwrap();
+        let layers = self.layers.read().unwrap();
+        let stack_name = stack.into();
+        let stack = tc.stack(&stack_name);
+        assert_eq!(stack.layers.len(), 3);
+
+        let ctlay_name = &stack.layers[1];
+        let ctlay = layers.keyname(&stack.layers[1]).unwrap();
+
+        let mut elems = Vec::new();
+
+        let x0 = 0;
+        let y0 = 0;
+
+        let ctw = tc.layer(&ctlay_name).width;
+        let cts = tc.layer(&ctlay_name).space;
+        let ctbw = ctw * cols + cts * (cols - 1);
+        let ctbh = ctw * rows + cts * (rows - 1);
+
+        let ct_bbox = Rect {
+            p0: Point::new(x0, y0),
+            p1: Point::new(x0 + ctbw, y0 + ctbh),
+        };
+
+        for i in 0..rows {
+            for j in 0..cols {
+                let left = x0 + j * (ctw + cts);
+                let bot = y0 + i * (ctw + cts);
+                let ct_box = Rect {
+                    p0: Point::new(left, bot),
+                    p1: Point::new(left + ctw, bot + ctw),
+                };
+
+                elems.push(Element {
+                    net: None,
+                    layer: ctlay,
+                    purpose: LayerPurpose::Drawing,
+                    inner: Shape::Rect(ct_box),
+                });
+            }
+        }
+
+        for lay_name in [&stack.layers[0], &stack.layers[2]] {
+            let lay = layers.keyname(lay_name).unwrap();
+            let mut laybox = ct_bbox.clone();
+            expand_box(&mut laybox, tc.layer(ctlay_name).enclosure(lay_name));
+            let ose = tc.layer(ctlay_name).one_side_enclosure(&lay_name);
+            laybox.p0.x = std::cmp::min(laybox.p0.x, ct_bbox.p0.x - ose);
+            laybox.p1.x = std::cmp::max(laybox.p0.x, ct_bbox.p1.x + ose);
+
+            elems.push(Element {
+                net: None,
+                layer: lay,
+                purpose: LayerPurpose::Drawing,
+                inner: Shape::Rect(laybox),
+            });
+        }
+
+        let name = format!("{}_{}x{}", stack_name, rows, cols);
+
+        let layout = Layout {
+            name: name.clone(),
+            insts: vec![],
+            annotations: vec![],
+            elems,
+        };
+
+        let cell = Cell {
+            name,
+            abs: None,
+            layout: Some(layout),
+        };
+
+        Ptr::new(cell)
+    }
+}
+
+fn expand_box(b: &mut Rect, dist: Int) {
+    assert!(b.p0.x <= b.p1.x);
+    assert!(b.p0.y <= b.p1.y);
+
+    b.p0.x -= dist;
+    b.p1.x += dist;
+    b.p0.y -= dist;
+    b.p1.y += dist;
+}

--- a/pdkprims/src/contact.rs
+++ b/pdkprims/src/contact.rs
@@ -9,7 +9,7 @@ use layout21::utils::Ptr;
 use serde::{Deserialize, Serialize};
 
 use crate::config::Int;
-use crate::geometry::CoarseDirection;
+use crate::geometry::{expand_box, CoarseDirection};
 use crate::{config::Uint, Pdk};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, derive_builder::Builder)]
@@ -230,22 +230,5 @@ impl Pdk {
             cols: params.cols,
             bboxes: bbox_map,
         }
-    }
-}
-
-fn expand_box(b: &mut Rect, dist: Int) {
-    assert!(b.p0.x <= b.p1.x);
-    assert!(b.p0.y <= b.p1.y);
-
-    b.p0.x -= dist;
-    b.p1.x += dist;
-    b.p0.y -= dist;
-    b.p1.y += dist;
-}
-
-fn rect_from_bbox(bbox: &BoundBox) -> Rect {
-    Rect {
-        p0: bbox.p0.clone(),
-        p1: bbox.p1.clone(),
     }
 }

--- a/pdkprims/src/contact.rs
+++ b/pdkprims/src/contact.rs
@@ -3,15 +3,15 @@ use std::fmt::Display;
 use std::sync::Arc;
 
 use layout21::raw::{
-    Abstract, AbstractPort, BoundBox, BoundBoxTrait, Cell, Element, LayerKey, LayerPurpose, Layout,
-    Point, Rect, Shape,
+    Abstract, AbstractPort, BoundBoxTrait, Cell, Element, LayerKey, LayerPurpose, Layout, Point,
+    Rect, Shape,
 };
 use layout21::utils::Ptr;
 use serde::{Deserialize, Serialize};
 
-use crate::Ref;
 use crate::config::Int;
 use crate::geometry::{expand_box, rect_from_bbox, CoarseDirection};
+use crate::Ref;
 use crate::{config::Uint, Pdk};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, derive_builder::Builder)]

--- a/pdkprims/src/geometry.rs
+++ b/pdkprims/src/geometry.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use layout21::raw::{BoundBox, Rect};
 use serde::{Deserialize, Serialize};
 
 /// A direction: horizontal or vertical.
@@ -30,5 +31,22 @@ impl CoarseDirection {
             Self::Horizontal => "h",
             Self::Vertical => "v",
         }
+    }
+}
+
+pub fn expand_box(b: &mut Rect, dist: crate::config::Int) {
+    assert!(b.p0.x <= b.p1.x);
+    assert!(b.p0.y <= b.p1.y);
+
+    b.p0.x -= dist;
+    b.p1.x += dist;
+    b.p0.y -= dist;
+    b.p1.y += dist;
+}
+
+fn rect_from_bbox(bbox: &BoundBox) -> Rect {
+    Rect {
+        p0: bbox.p0.clone(),
+        p1: bbox.p1.clone(),
     }
 }

--- a/pdkprims/src/geometry.rs
+++ b/pdkprims/src/geometry.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 
 /// A direction: horizontal or vertical.
@@ -10,5 +12,23 @@ pub enum CoarseDirection {
 impl Default for CoarseDirection {
     fn default() -> Self {
         Self::Vertical
+    }
+}
+
+impl Display for CoarseDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::Horizontal => write!(f, "horizontal"),
+            Self::Vertical => write!(f, "vertical"),
+        }
+    }
+}
+
+impl CoarseDirection {
+    pub fn short_form(&self) -> &'static str {
+        match *self {
+            Self::Horizontal => "h",
+            Self::Vertical => "v",
+        }
     }
 }

--- a/pdkprims/src/geometry.rs
+++ b/pdkprims/src/geometry.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+/// A direction: horizontal or vertical.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CoarseDirection {
+    Horizontal,
+    Vertical,
+}
+
+impl Default for CoarseDirection {
+    fn default() -> Self {
+        Self::Vertical
+    }
+}

--- a/pdkprims/src/geometry.rs
+++ b/pdkprims/src/geometry.rs
@@ -44,7 +44,7 @@ pub fn expand_box(b: &mut Rect, dist: crate::config::Int) {
     b.p1.y += dist;
 }
 
-fn rect_from_bbox(bbox: &BoundBox) -> Rect {
+pub fn rect_from_bbox(bbox: &BoundBox) -> Rect {
     Rect {
         p0: bbox.p0.clone(),
         p1: bbox.p1.clone(),

--- a/pdkprims/src/lib.rs
+++ b/pdkprims/src/lib.rs
@@ -1,6 +1,10 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use config::TechConfig;
+use contact::ContactParams;
 use layout21::{
     raw::{Cell, Element, LayerPurpose, Layers, Layout, LayoutResult, Library, Point, Rect, Shape},
     utils::Ptr,
@@ -12,17 +16,22 @@ pub mod geometry;
 pub mod mos;
 pub mod tech;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Pdk {
     pub config: Ptr<TechConfig>,
     pub layers: Ptr<Layers>,
+    contacts: Ptr<HashMap<ContactParams, Ptr<Cell>>>,
 }
 
 impl Pdk {
     pub fn new(config: TechConfig) -> LayoutResult<Self> {
         let layers = Ptr::new(config.get_layers()?);
         let config = Ptr::new(config);
-        Ok(Self { config, layers })
+        Ok(Self {
+            config,
+            layers,
+            contacts: Ptr::new(HashMap::new()),
+        })
     }
     #[inline]
     pub fn config(&self) -> Ptr<TechConfig> {

--- a/pdkprims/src/lib.rs
+++ b/pdkprims/src/lib.rs
@@ -1,15 +1,9 @@
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
+use std::{collections::HashMap, path::Path};
 
 use config::TechConfig;
 use contact::{Contact, ContactParams};
 use layout21::{
-    raw::{
-        Cell, Element, LayerKey, LayerPurpose, Layers, Layout, LayoutResult, Library, Point, Rect,
-        Shape,
-    },
+    raw::{Cell, LayerKey, Layers, LayoutResult, Library},
     utils::Ptr,
 };
 

--- a/pdkprims/src/lib.rs
+++ b/pdkprims/src/lib.rs
@@ -1,0 +1,74 @@
+use std::path::{Path, PathBuf};
+
+use config::TechConfig;
+use layout21::{
+    raw::{Cell, Element, LayerPurpose, Layers, Layout, LayoutResult, Library, Point, Rect, Shape},
+    utils::Ptr,
+};
+
+pub mod config;
+pub mod contact;
+pub mod geometry;
+pub mod mos;
+pub mod tech;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Pdk {
+    pub config: Ptr<TechConfig>,
+    pub layers: Ptr<Layers>,
+}
+
+impl Pdk {
+    pub fn new(config: TechConfig) -> LayoutResult<Self> {
+        let layers = Ptr::new(config.get_layers()?);
+        let config = Ptr::new(config);
+        Ok(Self { config, layers })
+    }
+    #[inline]
+    pub fn config(&self) -> Ptr<TechConfig> {
+        Ptr::clone(&self.config)
+    }
+
+    #[inline]
+    pub fn layers(&self) -> Ptr<Layers> {
+        Ptr::clone(&self.layers)
+    }
+
+    pub fn cell_to_gds(
+        &self,
+        cell: Ptr<Cell>,
+        path: impl AsRef<Path>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let cell_name = {
+            let cell = cell.read().unwrap();
+            cell.name.to_owned()
+        };
+        let mut lib = Library::new(&cell_name, self.config.read().unwrap().units);
+        lib.layers = self.layers();
+        lib.cells.push(cell);
+        let gds = lib.to_gds()?;
+        gds.save(path)?;
+        Ok(())
+    }
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use layout21::{raw::{Library, Cell}, utils::Ptr};
+//
+//     #[test]
+//     fn test_draw_mos() -> Result<(), Box<dyn std::error::Error>> {
+//         let tc = crate::sky130_config();
+//         let layout = crate::draw_mos((), &tc)?;
+//         let mut cell = Cell::new("ptx");
+//         cell.layout = Some(layout);
+//
+//         let mut lib = Library::new("test_draw_mos", tc.units);
+//         lib.layers = Ptr::new(tc.get_layers()?);
+//         lib.cells.push(Ptr::new(cell));
+//         let gds = lib.to_gds()?;
+//         gds.save("hi.gds")?;
+//
+//         Ok(())
+//     }
+// }

--- a/pdkprims/src/lib.rs
+++ b/pdkprims/src/lib.rs
@@ -13,6 +13,8 @@ use layout21::{
     utils::Ptr,
 };
 
+pub type Ref<T> = std::sync::Arc<T>;
+
 pub mod config;
 pub mod contact;
 pub mod geometry;
@@ -23,7 +25,7 @@ pub mod tech;
 pub struct Pdk {
     pub config: Ptr<TechConfig>,
     pub layers: Ptr<Layers>,
-    contacts: Ptr<HashMap<ContactParams, Contact>>,
+    contacts: Ptr<HashMap<ContactParams, Ref<Contact>>>,
 }
 
 impl Pdk {

--- a/pdkprims/src/lib.rs
+++ b/pdkprims/src/lib.rs
@@ -4,9 +4,12 @@ use std::{
 };
 
 use config::TechConfig;
-use contact::ContactParams;
+use contact::{Contact, ContactParams};
 use layout21::{
-    raw::{Cell, Element, LayerPurpose, Layers, Layout, LayoutResult, Library, Point, Rect, Shape},
+    raw::{
+        Cell, Element, LayerKey, LayerPurpose, Layers, Layout, LayoutResult, Library, Point, Rect,
+        Shape,
+    },
     utils::Ptr,
 };
 
@@ -20,7 +23,7 @@ pub mod tech;
 pub struct Pdk {
     pub config: Ptr<TechConfig>,
     pub layers: Ptr<Layers>,
-    contacts: Ptr<HashMap<ContactParams, Ptr<Cell>>>,
+    contacts: Ptr<HashMap<ContactParams, Contact>>,
 }
 
 impl Pdk {
@@ -58,6 +61,11 @@ impl Pdk {
         let gds = lib.to_gds()?;
         gds.save(path)?;
         Ok(())
+    }
+
+    pub fn get_layerkey(&self, layer: &str) -> Option<LayerKey> {
+        let layers = self.layers.read().unwrap();
+        layers.keyname(layer)
     }
 }
 

--- a/pdkprims/src/mos.rs
+++ b/pdkprims/src/mos.rs
@@ -76,6 +76,7 @@ pub struct MosDevice {
     /// The type of transistor
     pub mos_type: MosType,
     /// Transistor flavor
+    #[builder(default)]
     pub intent: Intent,
     /// The channel length of the transistor. The units must match
     /// those of the `[crate::Pdk]` you will use to draw the device.
@@ -84,12 +85,28 @@ pub struct MosDevice {
     /// those of the `[crate::Pdk]` you will use to draw the device.
     pub width: Int,
     /// The number of fingers to draw
+    #[builder(default = "1")]
     pub fingers: Uint,
+
+    /// Omit placing metal contacts on these sources/drains.
+    ///
+    /// Entered as a list of indices. Index 0 corresponds to the
+    /// bottom-most source/drain region. The maximum allowed index
+    /// is the number of fingers of the transistor being drawn.
+    ///
+    /// Usually, this list should never contain 0 or `nf`. Otherwise,
+    /// those sources/drains will be floating.
+    #[builder(default)]
+    pub skip_sd_metal: Vec<usize>,
 }
 
 impl MosDevice {
     pub fn builder() -> MosDeviceBuilder {
         MosDeviceBuilder::default()
+    }
+    pub fn skip_sd_metal(&mut self, idx: usize) -> &mut Self {
+        self.skip_sd_metal.push(idx);
+        self
     }
 }
 
@@ -129,16 +146,6 @@ pub struct MosParams {
 
     /// Specifies how to place gate contacts
     pub contact_strategy: GateContactStrategy,
-
-    /// Omit placing metal contacts on these sources/drains.
-    ///
-    /// Entered as a list of indices. Index 0 corresponds to the
-    /// bottom-most source/drain region. The maximum allowed index
-    /// is the number of fingers of the transistor being drawn.
-    ///
-    /// Usually, this list should never contain 0 or `nf`. Otherwise,
-    /// those sources/drains will be floating.
-    pub skip_sd_metal: Vec<usize>,
 }
 
 impl MosParams {
@@ -164,10 +171,6 @@ impl MosParams {
 
     pub fn add_device(&mut self, device: MosDevice) -> &mut Self {
         self.devices.push(device);
-        self
-    }
-    pub fn skip_sd_metal(&mut self, idx: usize) -> &mut Self {
-        self.skip_sd_metal.push(idx);
         self
     }
 

--- a/pdkprims/src/mos.rs
+++ b/pdkprims/src/mos.rs
@@ -1,0 +1,223 @@
+use std::fmt::Display;
+
+use layout21::raw::LayoutError;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    config::{Int, Uint},
+    geometry::CoarseDirection,
+};
+
+/// MOSFET Types
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum MosType {
+    /// An n-channel transistor
+    Nmos,
+    /// A p-channel transistor
+    Pmos,
+}
+
+impl Default for MosType {
+    fn default() -> Self {
+        Self::Nmos
+    }
+}
+
+impl Display for MosType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            MosType::Nmos => write!(f, "nmos"),
+            MosType::Pmos => write!(f, "pmos"),
+        }
+    }
+}
+
+/// Different flavors of MOSFETs.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Intent {
+    /// Ultra low threshold voltage
+    Ulvt,
+    /// Low threshold voltage
+    Lvt,
+    /// Standard threshold voltage
+    Svt,
+    /// High threshold voltage
+    Hvt,
+    /// Ultra-high threshold voltage
+    Uhvt,
+    /// A custom transistor flavor; effect depends on
+    /// PDK specific transistor generator.
+    Custom(String),
+}
+
+impl Default for Intent {
+    fn default() -> Self {
+        Self::Svt
+    }
+}
+
+impl Display for Intent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::Ulvt => write!(f, "ulvt"),
+            Self::Lvt => write!(f, "lvt"),
+            Self::Svt => write!(f, "svt"),
+            Self::Hvt => write!(f, "hvt"),
+            Self::Uhvt => write!(f, "uhvt"),
+            Self::Custom(ref s) => write!(f, "{}", s),
+        }
+    }
+}
+
+/// A representation of all the layout parameters
+/// of a single MOS device.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, derive_builder::Builder)]
+pub struct MosDevice {
+    /// The type of transistor
+    pub mos_type: MosType,
+    /// Transistor flavor
+    pub intent: Intent,
+    /// The channel length of the transistor. The units must match
+    /// those of the `[crate::Pdk]` you will use to draw the device.
+    pub length: Int,
+    /// The width of a single finger of the transistor. The units must match
+    /// those of the `[crate::Pdk]` you will use to draw the device.
+    pub width: Int,
+    /// The number of fingers to draw
+    pub fingers: Uint,
+}
+
+impl MosDevice {
+    pub fn builder() -> MosDeviceBuilder {
+        MosDeviceBuilder::default()
+    }
+}
+
+/// Specifies the geometric arrangement of contacts for transistor gates.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum GateContactStrategy {
+    /// Attempt to place all contacts on one side (usually the left)
+    SingleSide,
+    /// Alternate contact placement
+    Alternate,
+    /// ABBA placement
+    Abba,
+    /// Other; effect depends on layout generator
+    Other(String),
+}
+
+impl Default for GateContactStrategy {
+    fn default() -> Self {
+        Self::SingleSide
+    }
+}
+
+/// Parameters for generating MOSFET layouts
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MosParams {
+    /// A list of devices to draw.
+    pub devices: Vec<MosDevice>,
+    /// Direction in which to draw MOSFET gates.
+    ///
+    /// Note that some processes do not allow transistors
+    /// to be rotated 90 degrees.
+    pub direction: CoarseDirection,
+    /// If true, place devices in a deep n-well.
+    ///
+    /// May not be supported by all processes.
+    pub dnw: bool,
+
+    /// Specifies how to place gate contacts
+    pub contact_strategy: GateContactStrategy,
+
+    /// Omit placing metal contacts on these sources/drains.
+    ///
+    /// Entered as a list of indices. Index 0 corresponds to the
+    /// bottom-most source/drain region. The maximum allowed index
+    /// is the number of fingers of the transistor being drawn.
+    ///
+    /// Usually, this list should never contain 0 or `nf`. Otherwise,
+    /// those sources/drains will be floating.
+    pub skip_sd_metal: Vec<usize>,
+}
+
+impl MosParams {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    #[inline]
+    pub fn direction(&mut self, direction: CoarseDirection) -> &mut Self {
+        self.direction = direction;
+        self
+    }
+    #[inline]
+    pub fn dnw(&mut self, dnw: bool) -> &mut Self {
+        self.dnw = dnw;
+        self
+    }
+    #[inline]
+    pub fn contact_strategy(&mut self, contact_strategy: GateContactStrategy) -> &mut Self {
+        self.contact_strategy = contact_strategy;
+        self
+    }
+
+    pub fn add_device(&mut self, device: MosDevice) -> &mut Self {
+        self.devices.push(device);
+        self
+    }
+    pub fn skip_sd_metal(&mut self, idx: usize) -> &mut Self {
+        self.skip_sd_metal.push(idx);
+        self
+    }
+
+    pub fn validate(&self) -> Result<(), MosError> {
+        if self.devices.is_empty() {
+            return Err(MosError::NoDevices);
+        }
+
+        let start = &self.devices[0];
+        if start.fingers <= 0 {
+            return Err(MosError::InvalidNumFingers(start.fingers));
+        }
+
+        for device in self.devices.iter().skip(1) {
+            if device.length != start.length {
+                return Err(MosError::MismatchedLengths);
+            } else if device.fingers != start.fingers {
+                return Err(MosError::MismatchedFingers);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn length(&self) -> Int {
+        self.devices[0].length
+    }
+
+    #[inline]
+    pub fn fingers(&self) -> Uint {
+        self.devices[0].fingers
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MosError {
+    #[error("mismatched lengths (not all devices have the same channel length)")]
+    MismatchedLengths,
+    #[error("mismatched number of fingers (not all devices have the same number of fingers)")]
+    MismatchedFingers,
+    #[error("invalid number of fingers: {0}")]
+    InvalidNumFingers(Uint),
+    #[error("invalid params: {0}")]
+    BadParams(String),
+    #[error("no devices to draw")]
+    NoDevices,
+
+    #[error("error doing layout: {0}")]
+    Layout(#[from] LayoutError),
+}
+
+pub type MosResult<T> = std::result::Result<T, MosError>;

--- a/pdkprims/src/tech/mod.rs
+++ b/pdkprims/src/tech/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "sky130")]
+pub mod sky130;

--- a/pdkprims/src/tech/sky130/mod.rs
+++ b/pdkprims/src/tech/sky130/mod.rs
@@ -72,6 +72,15 @@ impl Pdk {
             };
 
             if d.mos_type == MosType::Pmos {
+                let mut psdm_box = rect.clone();
+                expand_box(&mut psdm_box, tc.layer("diff").enclosure("psdm"));
+                elems.push(Element {
+                    net: None,
+                    layer: layers.keyname("psdm").unwrap(),
+                    purpose: LayerPurpose::Drawing,
+                    inner: Shape::Rect(psdm_box),
+                });
+
                 let mut well_box = rect.clone();
                 expand_box(&mut well_box, tc.layer("diff").enclosure("nwell"));
 
@@ -80,6 +89,15 @@ impl Pdk {
                     layer: layers.keyname("nwell").unwrap(),
                     purpose: LayerPurpose::Drawing,
                     inner: Shape::Rect(well_box),
+                });
+            } else {
+                let mut nsdm_box = rect.clone();
+                expand_box(&mut nsdm_box, tc.layer("diff").enclosure("nsdm"));
+                elems.push(Element {
+                    net: None,
+                    layer: layers.keyname("nsdm").unwrap(),
+                    purpose: LayerPurpose::Drawing,
+                    inner: Shape::Rect(nsdm_box),
                 });
             }
 

--- a/pdkprims/src/tech/sky130/mod.rs
+++ b/pdkprims/src/tech/sky130/mod.rs
@@ -1,15 +1,15 @@
 use layout21::raw::{
-    BoundBoxTrait, Cell, Element, Instance, LayerPurpose, Layout, LayoutResult, Point, Rect, Shape,
+    Cell, Element, Instance, LayerPurpose, Layout, LayoutResult, Point, Rect, Shape,
 };
 use layout21::utils::Ptr;
 
 use crate::config::Int;
-use crate::contact::ContactParams;
-use crate::geometry::{expand_box, CoarseDirection};
+
+use crate::geometry::expand_box;
 use crate::mos::MosType;
 use crate::{
     config::TechConfig,
-    mos::{MosError, MosParams, MosResult},
+    mos::{MosParams, MosResult},
     Pdk,
 };
 

--- a/pdkprims/src/tech/sky130/mod.rs
+++ b/pdkprims/src/tech/sky130/mod.rs
@@ -1,0 +1,152 @@
+use layout21::raw::{Cell, Element, LayerPurpose, Layout, LayoutResult, Point, Rect, Shape};
+use layout21::utils::Ptr;
+
+use crate::config::Int;
+use crate::mos::MosType;
+use crate::{
+    config::TechConfig,
+    mos::{MosError, MosParams, MosResult},
+    Pdk,
+};
+
+#[cfg(test)]
+mod tests;
+
+const SKY130_DRC_CONFIG_TOML: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../tech/sky130/drc_config.toml"
+));
+
+fn tech_config() -> TechConfig {
+    TechConfig::from_toml(SKY130_DRC_CONFIG_TOML).expect("failed to load sky130A tech config")
+}
+
+pub fn pdk() -> LayoutResult<Pdk> {
+    Pdk::new(tech_config())
+}
+
+impl Pdk {
+    pub fn draw_sky130_mos(&self, params: MosParams) -> MosResult<Ptr<Cell>> {
+        params.validate()?;
+
+        let mut elems = Vec::new();
+
+        let tc = self.config.read().unwrap();
+        let layers = self.layers.read().unwrap();
+
+        let poly = layers.keyname("poly").unwrap();
+        let ndiff = layers.keyname("ndiff").unwrap();
+        let pdiff = layers.keyname("pdiff").unwrap();
+
+        let nf = params.fingers();
+
+        // Diff length perpendicular to gates
+        let diff_perp = 2 * ndiff_edge_to_gate(&tc)
+            + nf * tc.layer("poly").width
+            + (nf - 1) * finger_space(&tc);
+
+        let mut prev = None;
+        let x0 = 0;
+        let mut cx = x0;
+        let y0 = 0;
+        for d in params.devices.iter() {
+            if let Some(mt) = prev {
+                if mt != d.mos_type {
+                    cx += ndiff_to_pdiff(&tc);
+                } else {
+                    cx += tc.layer("ndiff").space;
+                }
+            }
+
+            let layer = match d.mos_type {
+                MosType::Nmos => ndiff,
+                MosType::Pmos => pdiff,
+            };
+
+            let rect = Rect {
+                p0: Point::new(cx, y0),
+                p1: Point::new(cx + d.width, y0 + diff_perp),
+            };
+
+            elems.push(Element {
+                net: None,
+                layer,
+                purpose: LayerPurpose::Drawing,
+                inner: Shape::Rect(rect),
+            });
+
+            cx += d.width;
+
+            prev = Some(d.mos_type);
+        }
+
+        let xpoly = x0 - tc.layer("poly").extension("ndiff");
+        let mut ypoly = y0 + ndiff_edge_to_gate(&tc);
+        let wpoly = cx - xpoly + tc.layer("poly").extension("ndiff");
+        for _ in 0..nf {
+            let rect = Rect {
+                p0: Point::new(xpoly, ypoly),
+                p1: Point::new(xpoly + wpoly, ypoly + params.length()),
+            };
+
+            elems.push(Element {
+                net: None,
+                layer: poly,
+                purpose: LayerPurpose::Drawing,
+                inner: Shape::Rect(rect),
+            });
+
+            ypoly += params.length();
+            ypoly += finger_space(&tc);
+        }
+
+        let layout = Layout {
+            name: "ptx".to_string(),
+            insts: vec![],
+            annotations: vec![],
+            elems,
+        };
+
+        let cell = Cell {
+            name: "ptx".to_string(),
+            abs: None,
+            layout: Some(layout),
+        };
+
+        Ok(Ptr::new(cell))
+    }
+}
+
+pub fn finger_space(tc: &TechConfig) -> Int {
+    [
+        2 * tc.space("gate", "licon") + tc.layer("li").width,
+        tc.layer("poly").space,
+    ]
+    .into_iter()
+    .max()
+    .unwrap()
+}
+
+pub fn ndiff_edge_to_gate(tc: &TechConfig) -> Int {
+    [
+        tc.layer("ndiff").extension("poly"),
+        tc.space("gate", "licon") + tc.layer("licon").width + tc.layer("licon").enclosure("ndiff"),
+    ]
+    .into_iter()
+    .max()
+    .unwrap()
+}
+
+pub fn pdiff_edge_to_gate(tc: &TechConfig) -> Int {
+    [
+        tc.layer("pdiff").extension("poly"),
+        tc.space("gate", "licon") + tc.layer("licon").width + tc.layer("licon").enclosure("ndiff"),
+    ]
+    .into_iter()
+    .max()
+    .unwrap()
+}
+
+pub fn ndiff_to_pdiff(tc: &TechConfig) -> Int {
+    tc.space("ndiff", "nwell") + tc.layer("pdiff").enclosure("nwell")
+}

--- a/pdkprims/src/tech/sky130/mod.rs
+++ b/pdkprims/src/tech/sky130/mod.rs
@@ -5,7 +5,7 @@ use layout21::utils::Ptr;
 
 use crate::config::Int;
 use crate::contact::ContactParams;
-use crate::geometry::CoarseDirection;
+use crate::geometry::{expand_box, CoarseDirection};
 use crate::mos::MosType;
 use crate::{
     config::TechConfig,
@@ -70,6 +70,18 @@ impl Pdk {
                 p0: Point::new(cx, y0),
                 p1: Point::new(cx + d.width, y0 + diff_perp),
             };
+
+            if d.mos_type == MosType::Pmos {
+                let mut well_box = rect.clone();
+                expand_box(&mut well_box, tc.layer("diff").enclosure("nwell"));
+
+                elems.push(Element {
+                    net: None,
+                    layer: layers.keyname("nwell").unwrap(),
+                    purpose: LayerPurpose::Drawing,
+                    inner: Shape::Rect(well_box),
+                });
+            }
 
             elems.push(Element {
                 net: None,

--- a/pdkprims/src/tech/sky130/mod.rs
+++ b/pdkprims/src/tech/sky130/mod.rs
@@ -141,7 +141,11 @@ impl Pdk {
                 if d.skip_sd_metal.contains(&(i as usize)) {
                     continue;
                 }
-                let ct = self.get_contact_sized("diffc", diff, d.width).unwrap();
+                let ct_stack = match d.mos_type {
+                    MosType::Nmos => "ndiffc",
+                    MosType::Pmos => "pdiffc",
+                };
+                let ct = self.get_contact_sized(ct_stack, diff, d.width).unwrap();
                 let bbox = ct.bboxes.get(&diff).unwrap();
                 let ofsx = (d.width - rect_width(bbox)) / 2;
                 let inst = Instance {

--- a/pdkprims/src/tech/sky130/tests.rs
+++ b/pdkprims/src/tech/sky130/tests.rs
@@ -63,7 +63,7 @@ fn test_sky130_draw_contact() -> Result<(), Box<dyn std::error::Error>> {
 
     for i in 1..=n {
         for j in 1..=i {
-            for stack in ["diffc", "polyc", "viali", "via1", "via2"] {
+            for stack in ["ndiffc", "pdiffc", "polyc", "viali", "via1", "via2"] {
                 for dir in [CoarseDirection::Vertical, CoarseDirection::Horizontal] {
                     let mut cp = ContactParams::builder();
                     let cp = cp
@@ -90,11 +90,11 @@ fn test_sky130_contact_sized() -> Result<(), Box<dyn std::error::Error>> {
     let pdk = super::pdk()?;
 
     let diff = pdk.get_layerkey("diff").unwrap();
-    let ct = pdk.get_contact_sized("diffc", diff, 330).unwrap();
+    let ct = pdk.get_contact_sized("ndiffc", diff, 330).unwrap();
     assert_eq!(ct.cols, 1);
     assert_eq!(ct.rows, 1);
 
-    let ct = pdk.get_contact_sized("diffc", diff, 650).unwrap();
+    let ct = pdk.get_contact_sized("ndiffc", diff, 650).unwrap();
     assert_eq!(ct.cols, 2);
     assert_eq!(ct.rows, 1);
 

--- a/pdkprims/src/tech/sky130/tests.rs
+++ b/pdkprims/src/tech/sky130/tests.rs
@@ -13,6 +13,7 @@ use crate::{
 
 #[test]
 fn test_draw_sky130_mos_nand2() -> Result<(), Box<dyn std::error::Error>> {
+    setup()?;
     let mut params = MosParams::new();
     params
         .dnw(false)
@@ -54,6 +55,7 @@ fn test_draw_sky130_mos_nand2() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_sky130_draw_contact() -> Result<(), Box<dyn std::error::Error>> {
+    setup()?;
     let n = 5;
 
     let pdk = super::pdk()?;
@@ -87,6 +89,7 @@ fn test_sky130_draw_contact() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn test_sky130_contact_sized() -> Result<(), Box<dyn std::error::Error>> {
+    setup()?;
     let pdk = super::pdk()?;
 
     let diff = pdk.get_layerkey("diff").unwrap();
@@ -105,4 +108,10 @@ fn output(name: impl AsRef<Path>) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../_build/")
         .join(name)
+}
+
+fn setup() -> Result<(), Box<dyn std::error::Error>> {
+    std::fs::create_dir_all( PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../_build/"))?;
+    Ok(())
 }

--- a/pdkprims/src/tech/sky130/tests.rs
+++ b/pdkprims/src/tech/sky130/tests.rs
@@ -23,6 +23,7 @@ fn test_draw_sky130_mos_nand2() -> Result<(), Box<dyn std::error::Error>> {
             length: 150,
             fingers: 2,
             intent: crate::mos::Intent::Svt,
+            skip_sd_metal: vec![1],
         })
         .add_device(MosDevice {
             mos_type: MosType::Pmos,
@@ -30,6 +31,7 @@ fn test_draw_sky130_mos_nand2() -> Result<(), Box<dyn std::error::Error>> {
             length: 150,
             fingers: 2,
             intent: crate::mos::Intent::Svt,
+            skip_sd_metal: vec![],
         });
 
     let pdk = super::pdk()?;
@@ -61,7 +63,7 @@ fn test_sky130_draw_contact() -> Result<(), Box<dyn std::error::Error>> {
 
     for i in 1..=n {
         for j in 1..=i {
-            for stack in ["polyc", "viali", "via1", "via2"] {
+            for stack in ["diffc", "polyc", "viali", "via1", "via2"] {
                 for dir in [CoarseDirection::Vertical, CoarseDirection::Horizontal] {
                     let mut cp = ContactParams::builder();
                     let cp = cp
@@ -71,8 +73,8 @@ fn test_sky130_draw_contact() -> Result<(), Box<dyn std::error::Error>> {
                         .dir(dir)
                         .build()
                         .unwrap();
-                    let cell = pdk.get_contact(&cp);
-                    lib.cells.push(cell);
+                    let ct = pdk.get_contact(&cp);
+                    lib.cells.push(ct.cell);
                 }
             }
         }
@@ -80,6 +82,22 @@ fn test_sky130_draw_contact() -> Result<(), Box<dyn std::error::Error>> {
 
     let gds = lib.to_gds()?;
     gds.save(output("test_sky130_draw_contact.gds"))?;
+    Ok(())
+}
+
+#[test]
+fn test_sky130_contact_sized() -> Result<(), Box<dyn std::error::Error>> {
+    let pdk = super::pdk()?;
+
+    let diff = pdk.get_layerkey("diff").unwrap();
+    let ct = pdk.get_contact_sized("diffc", diff, 330).unwrap();
+    assert_eq!(ct.cols, 1);
+    assert_eq!(ct.rows, 1);
+
+    let ct = pdk.get_contact_sized("diffc", diff, 650).unwrap();
+    assert_eq!(ct.cols, 2);
+    assert_eq!(ct.rows, 1);
+
     Ok(())
 }
 

--- a/pdkprims/src/tech/sky130/tests.rs
+++ b/pdkprims/src/tech/sky130/tests.rs
@@ -1,0 +1,72 @@
+use std::path::{Path, PathBuf};
+
+use layout21::raw::Library;
+
+use crate::{
+    geometry::CoarseDirection,
+    mos::{MosDevice, MosParams, MosType},
+};
+
+#[test]
+fn test_draw_sky130_mos_nand2() -> Result<(), Box<dyn std::error::Error>> {
+    let mut params = MosParams::new();
+    params
+        .dnw(false)
+        .direction(CoarseDirection::Horizontal)
+        .add_device(MosDevice {
+            mos_type: MosType::Nmos,
+            width: 1_000,
+            length: 150,
+            fingers: 2,
+            intent: crate::mos::Intent::Svt,
+        })
+        .add_device(MosDevice {
+            mos_type: MosType::Pmos,
+            width: 1_400,
+            length: 150,
+            fingers: 2,
+            intent: crate::mos::Intent::Svt,
+        });
+
+    let pdk = super::pdk()?;
+
+    let cell = pdk.draw_sky130_mos(params)?;
+
+    let mut lib = Library::new(
+        "test_draw_sky130_mos_nand2",
+        pdk.config.read().unwrap().units,
+    );
+    lib.layers = pdk.layers();
+    lib.cells.push(cell);
+    let gds = lib.to_gds()?;
+    gds.save("test_draw_sky130_mos_nand2.gds")?;
+
+    Ok(())
+}
+
+#[test]
+fn test_sky130_draw_contact() -> Result<(), Box<dyn std::error::Error>> {
+    let n = 5;
+
+    let pdk = super::pdk()?;
+
+    let mut lib = Library::new("test_sky130_draw_contact", pdk.config.read().unwrap().units);
+    lib.layers = pdk.layers();
+
+    for i in 1..=n {
+        for j in 1..=i {
+            let cell = pdk.get_contact("polyc", i, j);
+            lib.cells.push(cell);
+        }
+    }
+
+    let gds = lib.to_gds()?;
+    gds.save(output("test_sky130_draw_contact.gds"))?;
+    Ok(())
+}
+
+fn output(name: impl AsRef<Path>) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../_build/")
+        .join(name)
+}

--- a/pdkprims/src/tech/sky130/tests.rs
+++ b/pdkprims/src/tech/sky130/tests.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use layout21::{
     raw::{DepOrder, Library},
-    utils::PtrList,
+    utils::{PtrList, Ptr},
 };
 
 use crate::{
@@ -74,7 +74,7 @@ fn test_sky130_draw_contact() -> Result<(), Box<dyn std::error::Error>> {
                         .build()
                         .unwrap();
                     let ct = pdk.get_contact(&cp);
-                    lib.cells.push(ct.cell);
+                    lib.cells.push(Ptr::clone(&ct.cell));
                 }
             }
         }

--- a/pdkprims/src/tech/sky130/tests.rs
+++ b/pdkprims/src/tech/sky130/tests.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use layout21::raw::Library;
 
 use crate::{
+    contact::ContactParams,
     geometry::CoarseDirection,
     mos::{MosDevice, MosParams, MosType},
 };
@@ -55,8 +56,20 @@ fn test_sky130_draw_contact() -> Result<(), Box<dyn std::error::Error>> {
 
     for i in 1..=n {
         for j in 1..=i {
-            let cell = pdk.get_contact("polyc", i, j);
-            lib.cells.push(cell);
+            for stack in ["polyc", "viali", "via1", "via2"] {
+                for dir in [CoarseDirection::Vertical, CoarseDirection::Horizontal] {
+                    let mut cp = ContactParams::builder();
+                    let cp = cp
+                        .stack(stack.to_string())
+                        .rows(i)
+                        .cols(j)
+                        .dir(dir)
+                        .build()
+                        .unwrap();
+                    let cell = pdk.get_contact(&cp);
+                    lib.cells.push(cell);
+                }
+            }
         }
     }
 

--- a/pdkprims/src/tech/sky130/tests.rs
+++ b/pdkprims/src/tech/sky130/tests.rs
@@ -111,7 +111,6 @@ fn output(name: impl AsRef<Path>) -> PathBuf {
 }
 
 fn setup() -> Result<(), Box<dyn std::error::Error>> {
-    std::fs::create_dir_all( PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../_build/"))?;
+    std::fs::create_dir_all(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../_build/"))?;
     Ok(())
 }

--- a/pdkprims/src/tech/sky130/tests.rs
+++ b/pdkprims/src/tech/sky130/tests.rs
@@ -1,6 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use layout21::raw::Library;
+use layout21::{
+    raw::{DepOrder, Library},
+    utils::PtrList,
+};
 
 use crate::{
     contact::ContactParams,
@@ -39,8 +42,10 @@ fn test_draw_sky130_mos_nand2() -> Result<(), Box<dyn std::error::Error>> {
     );
     lib.layers = pdk.layers();
     lib.cells.push(cell);
+    let cells = DepOrder::order(&lib);
+    lib.cells = PtrList::from_ptrs(cells);
     let gds = lib.to_gds()?;
-    gds.save("test_draw_sky130_mos_nand2.gds")?;
+    gds.save(output("test_draw_sky130_mos_nand2.gds"))?;
 
     Ok(())
 }

--- a/pdkprims/src/tech/sky130/tests.rs
+++ b/pdkprims/src/tech/sky130/tests.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use layout21::{
     raw::{DepOrder, Library},
-    utils::{PtrList, Ptr},
+    utils::{Ptr, PtrList},
 };
 
 use crate::{

--- a/scripts/gds2svg.py
+++ b/scripts/gds2svg.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+
+import argparse
+import gdstk
+
+
+def getcell(cells, name):
+    for cell in cells:
+        print(cell.name)
+        if cell.name == name:
+            return cell
+    return None
+
+
+def gds2svg(input, cell, output):
+    print(f"gds2svg {input} > {output}")
+    lib = gdstk.read_gds(input)
+    cell = getcell(lib.cells, cell)
+    cell.write_svg(output, scaling=50000)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Convert a GDSII file to an SVG")
+    parser.add_argument("-i", "--input", required=True, help="the input file")
+    parser.add_argument(
+        "-c", "--cell", required=True, help="the cell to convert to SVG"
+    )
+    parser.add_argument("-o", "--output", required=False, help="The output file")
+    args = parser.parse_args()
+    gds2svg(args.input, args.cell, args.output)

--- a/sram22/Cargo.toml
+++ b/sram22/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Rahul Kumar <rahulkumar@berkeley.edu>"]
 description = "A configurable SRAM generator"
+license-file = "../LICENSE"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/sram22/src/cells/gates/nand/tests/mod.rs
+++ b/sram22/src/cells/gates/nand/tests/mod.rs
@@ -37,6 +37,7 @@ fn test_netlist_nand2() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+#[ignore]
 fn test_simulate_pex_nand2() -> Result<(), Box<dyn std::error::Error>> {
     let work_dir: PathBuf = "/tmp/sram22/tests/sim/nand2".into();
     let tc = sky130_config();

--- a/sram22/src/cells/mos/pm_sh.rs
+++ b/sram22/src/cells/mos/pm_sh.rs
@@ -243,6 +243,7 @@ pub mod tests {
     use crate::test_utils::*;
 
     #[test]
+    #[ignore]
     fn test_generate_pm_single_height_nf1() {
         let tc = sky130_config();
         let mut m = get_magic();
@@ -262,6 +263,7 @@ pub mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_generate_pm_single_height_nf2() {
         let tc = sky130_config();
         let mut m = get_magic();

--- a/sram22/src/config.rs
+++ b/sram22/src/config.rs
@@ -251,30 +251,3 @@ impl Extension {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use log::info;
-    use std::path::PathBuf;
-
-    #[test]
-    fn test_sky130_design_rules() -> Result<(), Box<dyn std::error::Error>> {
-        let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        p.push("../tech/sky130/drc_config.toml");
-        let tc = TechConfig::load(p)?;
-
-        info!("loaded config {:?}", tc);
-
-        assert_eq!(&tc.tech, "sky130A");
-        assert_eq!(tc.layer("poly").extension("ndiff").nm(), 130);
-        assert_eq!(tc.layer("poly").extension("pdiff").nm(), 130);
-
-        assert_eq!(tc.layer("poly").extension("pdiff").nm(), 130);
-
-        assert_eq!(tc.layer("licon").enclosure("poly").nm(), 50);
-        assert_eq!(tc.layer("licon").one_side_enclosure("poly").nm(), 80);
-
-        Ok(())
-    }
-}

--- a/tech/sky130/drc_config.toml
+++ b/tech/sky130/drc_config.toml
@@ -12,7 +12,10 @@ gamma = 1.3
 spacing = [
   { from = "diff", to = "nwell", dist = 340 },
   { from = "gate", to = "licon", dist = 55 }, # gate to source/drain contacts
+  { from = "gate", to = "npc", dist = 90 }, # gate to nitride poly cut
   { from = "licon", to = "diff", dist = 235 },
+  { from = "nsdm", to = "diff", dist = 130 }, # nsdm to opposite diff
+  { from = "psdm", to = "diff", dist = 130 }, # psdm to opposite diff
 ]
 
 [layers]
@@ -26,6 +29,36 @@ area = 0
 purposes = [
   ["Drawing", 20],
   ["Label", 5],
+]
+
+[layers.nsdm]
+desc = "define n+ source/drain implants"
+layernum = 93
+width = 380
+space = 380
+area = 265000
+purposes = [
+  ["Drawing", 44],
+]
+
+[layers.psdm]
+desc = "define p+ source/drain implants"
+layernum = 94
+width = 380
+space = 380
+area = 255000
+purposes = [
+  ["Drawing", 20],
+]
+
+[layers.npc]
+desc = "define nitride poly cuts under licon1 areas"
+layernum = 95
+width = 270
+space = 270
+area = 1
+purposes = [
+  ["Drawing", 20],
 ]
 
 [layers.ntap]
@@ -110,6 +143,7 @@ enclosures = [
   { layer = "ntap", enclosure = 40, one_side = false },
   { layer = "ptap", enclosure = 120, one_side = true },
   { layer = "ptap", enclosure = 40, one_side = false },
+  { layer = "npc", enclosure = 100, one_side = false },
 ]
 purposes = [
   ["Drawing", 44],
@@ -123,6 +157,8 @@ space = 270
 area = 63000
 enclosures = [
   { layer = "nwell", enclosure = 180, one_side = false },
+  { layer = "nsdm", enclosure = 125, one_side = false },
+  { layer = "psdm", enclosure = 125, one_side = false },
 ]
 extensions = [
   { layer = "poly", extend = 250 },

--- a/tech/sky130/drc_config.toml
+++ b/tech/sky130/drc_config.toml
@@ -25,6 +25,7 @@ space = 1270
 area = 0
 purposes = [
   ["Drawing", 20],
+  ["Label", 5],
 ]
 
 [layers.ntap]
@@ -65,6 +66,7 @@ extensions = [
 ]
 purposes = [
   ["Drawing", 20],
+  ["Label", 5],
 ]
 
 [layers.mcon]
@@ -89,6 +91,7 @@ space = 170
 area = 56100
 purposes = [
   ["Drawing", 20],
+  ["Label", 5],
 ]
 
 [layers.licon]
@@ -126,6 +129,7 @@ extensions = [
 ]
 purposes = [
   ["Drawing", 20],
+  ["Label", 6],
 ]
 
 [layers.m1]
@@ -136,6 +140,7 @@ space = 140
 area = 83000
 purposes = [
   ["Drawing", 20],
+  ["Label", 5],
 ]
 
 [layers.via]
@@ -160,6 +165,7 @@ space = 140
 area = 67600
 purposes = [
   ["Drawing", 20],
+  ["Label", 5],
 ]
 
 [layers.via2]
@@ -184,6 +190,7 @@ space = 140
 area = 67600
 purposes = [
   ["Drawing", 20],
+  ["Label", 5],
 ]
 
 [stacks]

--- a/tech/sky130/drc_config.toml
+++ b/tech/sky130/drc_config.toml
@@ -1,5 +1,7 @@
 tech = "sky130A"
-grid = 0.005
+
+units = "Nano"
+grid = 5
 
 # ratio of PMOS to NMOS widths for unit inverter
 beta = 1.54
@@ -8,158 +10,186 @@ beta = 1.54
 gamma = 1.3
 
 spacing = [
-  { from = "ndiff", to = "nwell", dist = 0.34 },
-  { from = "gate", to = "licon", dist = 0.055 }, # gate to source/drain contacts
-  { from = "licon", to = "pdiff", dist = 0.235 },
+  { from = "ndiff", to = "nwell", dist = 340 },
+  { from = "gate", to = "licon", dist = 55 }, # gate to source/drain contacts
+  { from = "licon", to = "pdiff", dist = 235 },
 ]
 
 [layers]
 
 [layers.nwell]
 desc = "define nwell for placing PMOS transistors"
-width = 0.84
-space = 1.27
-area = 0.0
+layernum = 64
+width = 840
+space = 1270
+area = 0
+purposes = [
+  ["Drawing", 20],
+]
 
 [layers.ntap]
 desc = "define n+ taps to nwell"
-width = 0.15
-space = 0.27
-area = 0.0
+layernum = 65
+width = 150
+space = 270
+area = 0
 enclosures = [
-  { layer = "nwell", enclosure = 0.18, one_side = false },
+  { layer = "nwell", enclosure = 180, one_side = false },
+]
+purposes = [
+  ["Drawing", 44],
 ]
 
 [layers.ptap]
 desc = "define p+ taps to substrate"
-width = 0.15
-space = 0.27
-area = 0.0
+layernum = 65
+width = 150
+space = 270
+area = 0
 enclosures = [
-  { layer = "pwell", enclosure = 0.13, one_side = false },
+  { layer = "pwell", enclosure = 130, one_side = false },
+]
+purposes = [
+  ["Drawing", 44],
 ]
 
 [layers.poly]
 desc = "define transistor gates"
-width = 0.15
-space = 0.21
-area = 0.0
+layernum = 66
+width = 150
+space = 210
+area = 0
 extensions = [
-  { layer = "ndiff", extend = 0.13 },
-  { layer = "pdiff", extend = 0.13 },
+  { layer = "ndiff", extend = 130 },
+  { layer = "pdiff", extend = 130 },
+]
+purposes = [
+  ["Drawing", 20],
 ]
 
-[layers.ct]
+[layers.mcon]
 desc = "contact between li and m1"
-width = 0.17
-space = 0.19
-area = 0.0289
+layernum = 67
+width = 170
+space = 190
+area = 28900
 enclosures = [
-  { layer = "m1", enclosure = 0.03, one_side = false },
-  { layer = "m1", enclosure = 0.06, one_side = true },
+  { layer = "m1", enclosure = 30, one_side = false },
+  { layer = "m1", enclosure = 60, one_side = true },
+]
+purposes = [
+  ["Drawing", 44],
 ]
 
 [layers.li]
 desc = "local interconnect"
-width = 0.17
-space = 0.17
-area = 0.0561
+layernum = 67
+width = 170
+space = 170
+area = 56100
+purposes = [
+  ["Drawing", 20],
+]
 
 [layers.licon]
 desc = "defines contacts between poly/diff/tap and local interconnect"
-width = 0.17
-space = 0.17
-area = 0.0289
+layernum = 66
+width = 170
+space = 170
+area = 28900
 enclosures = [
-  { layer = "ndiff", enclosure = 0.04, one_side = false },
-  { layer = "pdiff", enclosure = 0.04, one_side = false },
-  { layer = "ndiff", enclosure = 0.06, one_side = true },
-  { layer = "pdiff", enclosure = 0.06, one_side = true },
-  { layer = "poly", enclosure = 0.05, one_side = false },
-  { layer = "poly", enclosure = 0.08, one_side = true },
-  { layer = "li", enclosure = 0.08, one_side = true },
-  { layer = "ntap", enclosure = 0.12, one_side = true },
-  { layer = "ntap", enclosure = 0.04, one_side = false },
-  { layer = "ptap", enclosure = 0.12, one_side = true },
-  { layer = "ptap", enclosure = 0.04, one_side = false },
+  { layer = "ndiff", enclosure = 40, one_side = false },
+  { layer = "pdiff", enclosure = 40, one_side = false },
+  { layer = "ndiff", enclosure = 60, one_side = true },
+  { layer = "pdiff", enclosure = 60, one_side = true },
+  { layer = "poly", enclosure = 50, one_side = false },
+  { layer = "poly", enclosure = 80, one_side = true },
+  { layer = "li", enclosure = 80, one_side = true },
+  { layer = "ntap", enclosure = 120, one_side = true },
+  { layer = "ntap", enclosure = 40, one_side = false },
+  { layer = "ptap", enclosure = 120, one_side = true },
+  { layer = "ptap", enclosure = 40, one_side = false },
+]
+purposes = [
+  ["Drawing", 44],
 ]
 
 [layers.pdiff]
 desc = "pmos diffusion regions"
-width = 0.15
-space = 0.27
-area = 0.063
+layernum = 65
+width = 150
+space = 270
+area = 63000
 enclosures = [
-  { layer = "nwell", enclosure = 0.18, one_side = false },
+  { layer = "nwell", enclosure = 180, one_side = false },
 ]
 extensions = [
-  { layer = "poly", extend = 0.25 },
+  { layer = "poly", extend = 250 },
+]
+purposes = [
+  ["Drawing", 20],
 ]
 
 [layers.ndiff]
 desc = "nmos diffusion regions"
-width = 0.15
-space = 0.27
-area = 0.063
+layernum = 65
+width = 150
+space = 270
+area = 63000
 enclosures = [
-  { layer = "nwell", enclosure = 0.18, one_side = false },
+  { layer = "nwell", enclosure = 180, one_side = false },
 ]
 extensions = [
-  { layer = "poly", extend = 0.25 },
+  { layer = "poly", extend = 250 },
+]
+purposes = [
+  ["Drawing", 20],
 ]
 
 [layers.m1]
 desc = "first level of metal interconnects"
-width = 0.14
-space = 0.14
-area = 0.083
+layernum = 68
+width = 140
+space = 140
+area = 83000
+purposes = [
+  ["Drawing", 20],
+]
 
-[layers.via1]
+[layers.via]
 desc = "defines contacts between metal 1 and metal 2"
-width = 0.26
-space = 0.06
-area = 0.0676
+layernum = 68
+width = 260
+space = 60
+area = 67600
 enclosures = [
-  { layer = "m1", enclosure = 0.03, one_side = true },
-  { layer = "m2", enclosure = 0.03, one_side = true },
+  { layer = "m1", enclosure = 30, one_side = true },
+  { layer = "m2", enclosure = 30, one_side = true },
+]
+purposes = [
+  ["Drawing", 44],
 ]
 
 [layers.m2]
 desc = "first level of metal interconnects"
-width = 0.14
-space = 0.14
-area = 0.0676
+layernum = 69
+width = 140
+space = 140
+area = 67600
+purposes = [
+  ["Drawing", 20],
+]
 
 [stacks]
 
-[stacks.nsubdiffc]
-top_layer = "li"
-top_drc = "li"
-contact_layer = "nsubdiffc"
-contact_drc = "licon"
-bot_layer = "nsubdiff"
-bot_drc = "ntap"
-
 [stacks.polyc]
-top_layer = "li"
-top_drc = "li"
-contact_layer = "polyc"
-contact_drc = "licon"
-bot_layer = "li"
-bot_drc = "li"
-
+layers = ["li", "licon", "poly"]
+[stacks.diffc]
+layers = ["li", "licon", "diff"]
 [stacks.viali]
-top_layer = "m1"
-top_drc = "m1"
-contact_layer = "viali"
-contact_drc = "ct"
-bot_layer = "li"
-bot_drc = "li"
-
+layers = ["m1", "mcon", "li"]
 [stacks.via1]
-top_layer = "m2"
-top_drc = "m2"
-contact_layer = "via1"
-contact_drc = "via1"
-bot_layer = "m1"
-bot_drc = "m1"
+layers = ["m2", "via1", "m1"]
+[stacks.via2]
+layers = ["m3", "via2", "m2"]
+

--- a/tech/sky130/drc_config.toml
+++ b/tech/sky130/drc_config.toml
@@ -10,9 +10,9 @@ beta = 1.54
 gamma = 1.3
 
 spacing = [
-  { from = "ndiff", to = "nwell", dist = 340 },
+  { from = "diff", to = "nwell", dist = 340 },
   { from = "gate", to = "licon", dist = 55 }, # gate to source/drain contacts
-  { from = "licon", to = "pdiff", dist = 235 },
+  { from = "licon", to = "diff", dist = 235 },
 ]
 
 [layers]
@@ -60,8 +60,8 @@ width = 150
 space = 210
 area = 0
 extensions = [
-  { layer = "ndiff", extend = 130 },
-  { layer = "pdiff", extend = 130 },
+  { layer = "diff", extend = 130 },
+  { layer = "diff", extend = 130 },
 ]
 purposes = [
   ["Drawing", 20],
@@ -98,10 +98,8 @@ width = 170
 space = 170
 area = 28900
 enclosures = [
-  { layer = "ndiff", enclosure = 40, one_side = false },
-  { layer = "pdiff", enclosure = 40, one_side = false },
-  { layer = "ndiff", enclosure = 60, one_side = true },
-  { layer = "pdiff", enclosure = 60, one_side = true },
+  { layer = "diff", enclosure = 40, one_side = false },
+  { layer = "diff", enclosure = 60, one_side = true },
   { layer = "poly", enclosure = 50, one_side = false },
   { layer = "poly", enclosure = 80, one_side = true },
   { layer = "li", enclosure = 80, one_side = true },
@@ -114,24 +112,8 @@ purposes = [
   ["Drawing", 44],
 ]
 
-[layers.pdiff]
-desc = "pmos diffusion regions"
-layernum = 65
-width = 150
-space = 270
-area = 63000
-enclosures = [
-  { layer = "nwell", enclosure = 180, one_side = false },
-]
-extensions = [
-  { layer = "poly", extend = 250 },
-]
-purposes = [
-  ["Drawing", 20],
-]
-
-[layers.ndiff]
-desc = "nmos diffusion regions"
+[layers.diff]
+desc = "nmos/pmos diffusion regions"
 layernum = 65
 width = 150
 space = 270
@@ -171,8 +153,32 @@ purposes = [
 ]
 
 [layers.m2]
-desc = "first level of metal interconnects"
+desc = "second level of metal interconnects"
 layernum = 69
+width = 140
+space = 140
+area = 67600
+purposes = [
+  ["Drawing", 20],
+]
+
+[layers.via2]
+desc = "defines contacts between metal 1 and metal 2"
+layernum = 68
+width = 260
+space = 60
+area = 67600
+enclosures = [
+  { layer = "m1", enclosure = 30, one_side = true },
+  { layer = "m2", enclosure = 30, one_side = true },
+]
+purposes = [
+  ["Drawing", 44],
+]
+
+[layers.m3]
+desc = "third level of metal interconnects"
+layernum = 70
 width = 140
 space = 140
 area = 67600
@@ -189,7 +195,7 @@ layers = ["li", "licon", "diff"]
 [stacks.viali]
 layers = ["m1", "mcon", "li"]
 [stacks.via1]
-layers = ["m2", "via1", "m1"]
+layers = ["m2", "via", "m1"]
 [stacks.via2]
 layers = ["m3", "via2", "m2"]
 

--- a/tech/sky130/drc_config.toml
+++ b/tech/sky130/drc_config.toml
@@ -233,7 +233,9 @@ purposes = [
 
 [stacks.polyc]
 layers = ["li", "licon", "poly"]
-[stacks.diffc]
+[stacks.ndiffc]
+layers = ["li", "licon", "diff"]
+[stacks.pdiffc]
 layers = ["li", "licon", "diff"]
 [stacks.viali]
 layers = ["m1", "mcon", "li"]

--- a/tech/sky130/gds_layers.csv
+++ b/tech/sky130/gds_layers.csv
@@ -1,0 +1,270 @@
+Layer name,Purpose,GDS layer:datatype,Description
+diff,"drawing, text",65:20,Active (diffusion) area (type opposite of well/substrate underneath)
+tap,drawing,65:44,"Active (diffusion) area (type equal to the well/substrate underneath) (i.e., N+ and P+)"
+nwell,drawing,64:20,N-well region
+dnwell,drawing,64:18,Deep n-well region
+pwbm,drawing,19:44,Regions (in UHVI) blocked from p-well implant (DE MOS devices only)
+pwde,drawing,124:20,Regions to receive p-well drain-extended implants
+hvtr,drawing,18:20,High-Vt RF transistor implant
+hvtp,drawing,78:44,High-Vt LVPMOS implant
+ldntm,drawing,11:44,N-tip implant on SONOS devices
+hvi,drawing,75:20,High voltage (5.0V) thick oxide gate regions
+tunm,drawing,80:20,SONOS device tunnel implant
+lvtn,drawing,125:44,Low-Vt NMOS device
+poly,"drawing, text",66:20,Polysilicon
+hvntm,drawing,125:20,High voltage N-tip implant
+nsdm,drawing,93:44,N+ source/drain implant
+psdm,drawing,94:20,P+ source/drain implant
+rpm,drawing,86:20,300 ohms/square polysilicon resistor implant
+urpm,drawing,79:20,2000 ohms/square polysilicon resistor implant
+npc,drawing,95:20,Nitride poly cut (under licon1 areas)
+licon1,drawing,66:44,Contact to local interconnect
+li1,"drawing, text",67:20,Local interconnect
+mcon,drawing,67:44,Contact from local interconnect to metal1
+met1,"drawing, text",68:20,Metal 1
+via,drawing,68:44,Contact from metal 1 to metal 2
+met2,"drawing, text",69:20,Metal 2
+via2,drawing,69:44,Contact from metal 2 to metal 3
+met3,"drawing, text",70:20,Metal 3
+via3,drawing,70:44,Contact from metal 3 to metal 4
+met4,"drawing, text",71:20,Metal 4
+via4,drawing,71:44,Contact from metal 4 to metal 5
+met5,"drawing, text",72:20,Metal 5
+pad,"drawing, text",76:20,Passivation cut (opening over pads)
+nsm,drawing,61:20,Nitride seal mask
+capm,drawing,89:44,MiM capacitor plate over metal 3
+cap2m,drawing,97:44,MiM capacitor plate over metal 4
+vhvi,drawing,74:21,12V nominal (16V max) node identifier
+uhvi,drawing,74:22,20V nominal node identifier
+npn,drawing,82:20,Base region identifier for NPN devices
+inductor,drawing,82:24,Identifier for inductor regions
+capacitor,drawing,82:64,Identifier for interdigitated (vertical parallel plate (vpp)) capacitors
+pnp,drawing,82:44,Base nwell region identifier for PNP devices
+LVS prune,drawing,84:44,Exemption from LVS check (used in e-test modules only)
+ncm,drawing,92:44,N-core implant
+padCenter,drawing,81:20,Pad center marker
+target,drawing,76:44,Metal fuse target
+,,,
+areaid.sl,identifier,81:1,Seal ring identifier
+areaid.ce,identifier,81:2,Memory (SRAM) core cell identifier
+areaid.fe,identifier,81:3,Pads in padframe identifier
+areaid.sc,identifier,81:4,Standard cell identifier
+areaid.sf,identifier,81:6,Signal pad diffusion identifier (for latchup DRC checks)
+areaid.sl,identifier,81:7,Signal pad well identifier (for latchup DRC checks)
+areaid.sr,identifier,81:8,Signal pad metal (for latchup DRC checks)
+areaid.mt,identifier,81:10,Location of e-test modules within the frame
+areaid.dt,identifier,81:11,Location of dice within the frame
+areaid.ft,identifier,81:12,Boundary of the frame
+areaid.ww,identifier,81:13,Waffle window (used to prevent waffle shifting)
+areaid.ld,identifier,81:14,Low tap density (15um between taps) area.  Must be at least 50um from padframe 
+areaid.ns,identifier,81:15,Non-critical side.  Blocks stress DRC rules
+areaid.ij,identifier,81:17,Identification for areas susceptible to injection
+areaid.zr,identifier,81:18,Zener diode identifier
+areaid.ed,identifier,81:19,ESD device identifier
+areaid.de,identifier,81:23,Diode identifier
+areaid.rd,identifier,81:24,RDL probe pad (not used in this process)
+areaid.dn,identifier,81:50,Dead zone (used in seal ring only  for stress DRC)
+areaid.cr,identifier,81:51,Critical corner (used in seal ring only for stress DRC)
+areaid.cd,identifier,81:52,Critical side (used in seal ring only for stress DRC)
+areaid.st,identifier,81:53,Substrate cut.  Idendifies areas to be considered as isolated substrate
+areaid.op,identifier,81:54,OPC drop.  Block automatic OPC (for fab blocks and lithocal structures)
+areaid.en,identifier,81:57,Extended drain identifier
+areaid.en20,identifier,81:58,20V Extended drain identifier
+areaid.le,identifier,81:60,3.3V native NMOS identifier (absence indicates a 5V native NMOS)
+areaid.hl,identifier,81:63,HV nwell.  Identifies nwells with thin oxide devices connected to high voltage
+areaid.sd,identifier,81:70,subcircuit identifier (for LVS extraction)
+areaid.po,identifier,81:81,Photodiode device identifier
+areaid.it,identifier,81:84,IP exempt from DFM rules
+areaid.et,identifier,81:101,e-test module identifier
+areaid.lvt,identifier,81:108,Low-Vt identifier
+areaid.re,identifier,81:125,RF diode identifier
+,,,
+fom,dummy,22:23,
+,,,
+poly,gate,66:9,
+,,,
+poly,model,66:83,(Text type)
+,,,
+poly,resistor,66:13,
+diff,resistor,65:13,
+pwell,resistor,64:13,
+li1,resistor,67:13,
+,,,
+diff,high voltage,65:8,
+,,,
+met4,fuse,71:17,
+,,,
+inductor,terminal1,82:26,
+inductor,terminal2,82:27,
+inductor,terminal3,82:28,
+,,,
+li1,block,67:10,
+met1,block,68:10,
+met2,block,69:10,
+met3,block,70:10,
+met4,block,71:10,
+met5,block,72:10,
+,,,
+prBndry,boundary,235:4,
+diff,boundary,65:4,
+tap,boundary,65:60,
+mcon,boundary,67:60,
+poly,boundary,66:4,
+via,boundary,68:60,
+via2,boundary,69:60,
+via3,boundary,70:60,
+via4,boundary,71:60,
+,,,
+li1,label,67:5,(Text type)
+met1,label,68:5,(Text type)
+met2,label,69:5,(Text type)
+met3,label,70:5,(Text type)
+met4,label,71:5,(Text type)
+met5,label,72:5,(Text type)
+poly,label,66:5,(Text type)
+diff,label,65:6,(Text type)
+pwell,label,64:59,(Text and data type)
+pwelliso,label,44:5,(Text type)
+pad,label,76:5,(Text type)
+tap,label,65:5,
+nwell,label,64:5,
+inductor,label,82:25,
+,,,
+text,label,83:44,(Text type)
+,,,
+li1,net,67:23,(Text type)
+met1,net,68:23,(Text type)
+met2,net,69:23,(Text type)
+met3,net,70:23,(Text type)
+met4,net,71:23,(Text type)
+met5,net,72:23,(Text type)
+poly,net,66:23,(Text type)
+diff,net,65:23,(Text type)
+,,,
+li1,pin,67:16,(Text and data)
+met1,pin,68:16,(Text and data)
+met2,pin,69:16,(Text and data)
+met3,pin,70:16,(Text and data)
+met4,pin,71:16,(Text and data)
+met5,pin,72:16,(Text and data)
+poly,pin,66:16,(Text and data)
+diff,pin,65:16,(Text and data)
+nwell,pin,64:16,(Text type)
+pad,pin,76:16,(Text and data)
+pwell,pin,122:16,(Text and data)
+pwelliso,pin,44:16,(Text and data)
+,,,
+nwell,pin,64:0,(Text type)
+poly,pin,66:0,(Text type)
+li1,pin,67:0,(Text type)
+met1,pin,68:0,(Text type)
+met2,pin,69:0,(Text type)
+met3,pin,70:0,(Text type)
+met4,pin,71:0,(Text type)
+met5,pin,72:0,(Text type)
+pad,pin,76:0,(Text type)
+pwell,pin,122:0,(Text type)
+,,,
+diff,cut,65:14,
+poly,cut,66:14,
+li1,cut,67:14,
+met1,cut,68:14,
+met2,cut,69:14,
+met3,cut,70:14,
+met4,cut,71:14,
+met5,cut,72:14,
+pwell,cut,,
+,,,
+met5,probe,72:25,
+met4,probe,71:25,
+met3,probe,70:25,
+met2,probe,69:25,
+met1,probe,68:25,
+li1,probe,67:25,
+poly,probe,66:25,
+,,,
+poly,short,66:15,
+li1,short,67:15,
+met1,short,68:15,
+met2,short,69:15,
+met3,short,70:15,
+met4,short,71:15,
+met5,short,72:15,
+,,,
+Mask level data,,,
+,,,
+cncm,mask,17:0,N-core implant mask
+crpm,mask,96:0,Resistor Protect mask
+cpdm,mask,37:0,Pad mask
+cnsm,mask,22:0,Nitride seal mask
+cmm5,mask,59:0,Metal 5 mask
+cviam4,mask,58:0,Via 4 mask
+cmm4,mask,51:0,Metal 4 mask
+cviam3,mask,50:0,Via 3 mask
+cmm3,mask,34:0,Metal 3 mask
+cviam2,mask,44:0,Via 2 mask
+cmm2,mask,41:0,Metal 2 mask
+cviam,mask,40:0,Via mask
+cmm1,mask,36:0,Metal 1 mask
+ctm1,mask,35:0,Contact mask
+cli1m,mask,56:0,Local interconnect mask
+clicm1,mask,43:0,Local interconnect contact mask
+cpsdm,mask,32:0,P+ Implant mask
+cnsdm,mask,30:0,N+ Implant mask
+cldntm,mask,11:0,Lightly-doped N-tip implant mask
+cnpc,mask,49:0,Nitride poly cut mask
+chvntm,mask,39:0,High voltage N-tip implant mask
+cntm,mask,27:0,N-tip implant mask
+cp1m,mask,28:0,Poly 1 mask
+clvom,mask,46:0,Low Voltage oxide mask
+conom,mask,88:0,ONO Mask
+ctunm,mask,20:0,Tunnel mask
+chvtrm,mask,98:0,HLow VT PCh Radio mask
+chvtpm,mask,97:0,High Vt Pch mask
+clvtnm,mask,25:0,Low Vt Nch mask
+cnwm,mask,21:0,Nwell mask
+cdnm,mask,48:0,Deep nwell mask
+cfom,mask,23:0,Field oxide mask
+,,,
+cfom,drawing,22:20,
+clvtnm,drawing,25:44,
+chvtpm,drawing,88:44,
+conom,drawing,87:44,
+clvom,drawing,45:20,
+cntm,drawing,26:20,
+chvntm,drawing,38:20,
+cnpc,drawing,44:20,
+cnsdm,drawing,29:20,
+cpsdm,drawing,31:20,
+cli1m,drawing,115:44,
+cviam3,drawing,112:20,
+cviam4,drawing,117:20,
+cncm,drawing,96:44,
+,,,
+cntm,mask add,26:21,
+clvtnm,mask add,25:43,
+chvtpm,mask add,97:43,
+cli1m,mask add,115:43,
+clicm1,mask add,106:43,
+cpsdm,mask add,31:21,
+cnsdm,mask add,29:21,
+cp1m,mask add,33:43,
+cfom,mask add,22:21,
+,,,
+cntm,mask drop,26:22,
+clvtnm,mask drop,25:42,
+chvtpm,mask drop,97:42,
+cli1m,mask drop,115:42,
+clicm1,mask drop,106:42,
+cpsdm,mask drop,31:22,
+cnsdm,mask drop,29:22,
+cp1m,mask drop,33:42,
+cfom,mask drop,22:22,
+,,,
+cmm4,waffle drop,112:4,
+cmm3,waffle drop,107:24,
+cmm2,waffle drop,105:52,
+cmm1,waffle drop,62:24,
+cp1m,waffle drop,33:24,
+cfom,waffle drop,22:24,
+cmm5,waffle drop,117:4,


### PR DESCRIPTION
- add pdk prims with wip contact and mos generator
- remove ndiff/pdiff layers
- generate contacts when drawing mos (does not work yet)
- contact drawing also generates abstract layout view
- update drc config, centered contact placement, skip sd metal contacts
- update mos draw
- add drc rules for nsdm, psdm, npc
- add nsdm/psdm drawings
- draw nsdm/psdm/npc for appropriate contacts
- return references to contact structures
