### PR TITLE
Basic 3-input NAND gate generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,7 +459,7 @@ dependencies = [
 [[package]]
 name = "gds21"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#16a249030c987d7d4fb149f33b1c0d58bafbf71a"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#285020b67fcdbdb518412ec99ef8ac681b2d41b2"
 dependencies = [
  "byteorder",
  "chrono",
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.3.3"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360d9740069b2f6cbb63ce2dbaa71a20d3185350cbb990d7bebeb9318415eb17"
+checksum = "56b224eaa4987c03c30b251de7ef0c15a6a59f34222905850dbc3026dfb24d5f"
 dependencies = [
  "log",
  "pest",
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "layout21"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#16a249030c987d7d4fb149f33b1c0d58bafbf71a"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#285020b67fcdbdb518412ec99ef8ac681b2d41b2"
 dependencies = [
  "gds21",
  "layout21protos",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "layout21protos"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#16a249030c987d7d4fb149f33b1c0d58bafbf71a"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#285020b67fcdbdb518412ec99ef8ac681b2d41b2"
 dependencies = [
  "vlsir 0.2.0 (git+https://github.com/rahulk29/Vlsir.git?branch=main)",
 ]
@@ -644,7 +644,7 @@ dependencies = [
 [[package]]
 name = "layout21raw"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#16a249030c987d7d4fb149f33b1c0d58bafbf71a"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#285020b67fcdbdb518412ec99ef8ac681b2d41b2"
 dependencies = [
  "anyhow",
  "derive_builder 0.11.2",
@@ -663,7 +663,7 @@ dependencies = [
 [[package]]
 name = "layout21tetris"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#16a249030c987d7d4fb149f33b1c0d58bafbf71a"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#285020b67fcdbdb518412ec99ef8ac681b2d41b2"
 dependencies = [
  "derive_builder 0.9.0",
  "derive_more",
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "layout21utils"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#16a249030c987d7d4fb149f33b1c0d58bafbf71a"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#285020b67fcdbdb518412ec99ef8ac681b2d41b2"
 dependencies = [
  "by_address",
  "serde",
@@ -700,7 +700,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 [[package]]
 name = "lef21"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#16a249030c987d7d4fb149f33b1c0d58bafbf71a"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#285020b67fcdbdb518412ec99ef8ac681b2d41b2"
 dependencies = [
  "derive_builder 0.9.0",
  "derive_more",
@@ -805,7 +805,7 @@ checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 [[package]]
 name = "pdkprims"
 version = "0.0.1"
-source = "git+https://github.com/rahulk29/pdkprims.git?branch=master#4bf9f2aee4b49a7275164f00562499afc155d6ac"
+source = "git+https://github.com/rahulk29/pdkprims.git?branch=master#12dad6eaa5cafc3404a446c88c57d8df255735bd"
 dependencies = [
  "arcstr",
  "derive_builder 0.11.2",
@@ -820,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
+checksum = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -830,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905708f7f674518498c1f8d644481440f476d39ca6ecae83319bba7c6c12da91"
+checksum = "502b62a6d0245378b04ffe0a7fb4f4419a4815fce813bd8a0ec89a56e07d67b1"
 dependencies = [
  "pest",
  "pest_generator",
@@ -840,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5803d8284a629cc999094ecd630f55e91b561a1d1ba75e233b00ae13b91a69ad"
+checksum = "451e629bf49b750254da26132f1a5a9d11fd8a95a3df51d15c4abd1ba154cb6c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -853,13 +853,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1538eb784f07615c6d9a8ab061089c6c54a344c5b4301db51990ca1c241e8c04"
+checksum = "bcec162c71c45e269dfc3fc2916eaeb97feab22993a21bcce4721d08cd7801a6"
 dependencies = [
  "once_cell",
  "pest",
- "sha-1",
+ "sha1",
 ]
 
 [[package]]
@@ -1131,10 +1131,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.0"
+name = "sha1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "006769ba83e921b3085caa8334186b00cf92b4cb1a6cf4632fbccc8eff5c7549"
 dependencies = [
  "cfg-if",
  "cpufeatures",


### PR DESCRIPTION
Requires changes to the transistor generator in
pdkprims. Currently not DRC clean.
