### PR TITLE
Place decoder ntaps and ptaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 [[package]]
 name = "gds21"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#148b66bf8ca3dad2fa1ee71c63c92b0e5ba8218f"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#f0cea6e0eafc6158ba4f177fc9d7425e8be24013"
 dependencies = [
  "byteorder",
  "chrono",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "layout21"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#148b66bf8ca3dad2fa1ee71c63c92b0e5ba8218f"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#f0cea6e0eafc6158ba4f177fc9d7425e8be24013"
 dependencies = [
  "gds21",
  "layout21protos",
@@ -649,7 +649,7 @@ dependencies = [
 [[package]]
 name = "layout21protos"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#148b66bf8ca3dad2fa1ee71c63c92b0e5ba8218f"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#f0cea6e0eafc6158ba4f177fc9d7425e8be24013"
 dependencies = [
  "vlsir 0.2.0 (git+https://github.com/rahulk29/Vlsir.git?branch=main)",
 ]
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "layout21raw"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#148b66bf8ca3dad2fa1ee71c63c92b0e5ba8218f"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#f0cea6e0eafc6158ba4f177fc9d7425e8be24013"
 dependencies = [
  "anyhow",
  "derive_builder 0.11.2",
@@ -676,7 +676,7 @@ dependencies = [
 [[package]]
 name = "layout21tetris"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#148b66bf8ca3dad2fa1ee71c63c92b0e5ba8218f"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#f0cea6e0eafc6158ba4f177fc9d7425e8be24013"
 dependencies = [
  "derive_builder 0.9.0",
  "derive_more",
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "layout21utils"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#148b66bf8ca3dad2fa1ee71c63c92b0e5ba8218f"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#f0cea6e0eafc6158ba4f177fc9d7425e8be24013"
 dependencies = [
  "by_address",
  "serde",
@@ -713,7 +713,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 [[package]]
 name = "lef21"
 version = "0.2.1"
-source = "git+https://github.com/rahulk29/Layout21.git?branch=main#148b66bf8ca3dad2fa1ee71c63c92b0e5ba8218f"
+source = "git+https://github.com/rahulk29/Layout21.git?branch=main#f0cea6e0eafc6158ba4f177fc9d7425e8be24013"
 dependencies = [
  "derive_builder 0.9.0",
  "derive_more",
@@ -1214,9 +1214,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -159,53 +159,9 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
             .build()?,
     );
 
-    for (nand, inv) in [(&nand_dec, &inv_dec), (&wldrv_nand, &wldrv_inv)] {
-        let trace = connect(ConnectArgs {
-            metal_idx: 1,
-            port_idx: 0,
-            router: &mut router,
-            insts: GateList::Array(nand, rows),
-            port_name: "VDD",
-            dir: Dir::Vert,
-            overhang: Some(M1_PWR_OVERHANG),
-        });
-        power_grid.add_vdd_target(1, trace.rect());
-        let trace = connect(ConnectArgs {
-            metal_idx: 1,
-            port_idx: 0,
-            router: &mut router,
-            insts: GateList::Array(nand, rows),
-            port_name: "VSS",
-            dir: Dir::Vert,
-            overhang: Some(M1_PWR_OVERHANG),
-        });
-        power_grid.add_gnd_target(1, trace.rect());
-
-        let trace = connect(ConnectArgs {
-            metal_idx: 1,
-            port_idx: 0,
-            router: &mut router,
-            insts: GateList::Array(inv, rows),
-            port_name: "vdd",
-            dir: Dir::Vert,
-            overhang: Some(M1_PWR_OVERHANG),
-        });
-        power_grid.add_vdd_target(1, trace.rect());
-        let trace = connect(ConnectArgs {
-            metal_idx: 1,
-            port_idx: 0,
-            router: &mut router,
-            insts: GateList::Array(inv, rows),
-            port_name: "gnd",
-            dir: Dir::Vert,
-            overhang: Some(M1_PWR_OVERHANG),
-        });
-        power_grid.add_gnd_target(1, trace.rect());
-    }
-
     for i in 0..rows {
         // Connect decoder nand to decoder inverter
-        let src = nand_dec.port(format!("Y_{}", i)).largest_rect(m0).unwrap();
+        let src = nand_dec.port(format!("y_{}", i)).largest_rect(m0).unwrap();
         let dst = inv_dec.port(format!("din_{}", i)).largest_rect(m0).unwrap();
         let mut trace = router.trace(src, 0);
         trace.s_bend(dst, Dir::Horiz);
@@ -216,7 +172,7 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
             .largest_rect(m0)
             .unwrap();
         let dst = wldrv_nand
-            .port(format!("A_{}", i))
+            .port(format!("a_{}", i))
             .largest_rect(m0)
             .unwrap();
         let mut trace = router.trace(src, 0);
@@ -224,7 +180,7 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
 
         // Connect nand wldriver output to inv wldriver input.
         let src = wldrv_nand
-            .port(format!("Y_{}", i))
+            .port(format!("y_{}", i))
             .largest_rect(m0)
             .unwrap();
         let dst = wldrv_inv
@@ -606,6 +562,13 @@ pub(crate) struct ConnectArgs<'a> {
     pub(crate) dir: Dir,
     #[builder(setter(strip_option))]
     pub(crate) overhang: Option<isize>,
+}
+
+impl<'a> ConnectArgs<'a> {
+    #[inline]
+    pub fn builder() -> ConnectArgsBuilder<'a> {
+        ConnectArgsBuilder::default()
+    }
 }
 
 #[derive(Copy, Clone)]

--- a/sramgen/src/layout/common.rs
+++ b/sramgen/src/layout/common.rs
@@ -84,7 +84,6 @@ pub fn draw_two_level_contact(
 }
 
 #[derive(Copy, Clone, Builder)]
-#[builder(pattern = "owned")]
 pub(crate) struct MergeArgs<'a> {
     pub(crate) layer: LayerKey,
     pub(crate) insts: GateList<'a>,

--- a/sramgen/src/layout/gate.rs
+++ b/sramgen/src/layout/gate.rs
@@ -39,20 +39,20 @@ pub fn draw_and2(lib: &mut PdkLib, params: AndParams) -> Result<Ptr<Cell>> {
     let mut router = Router::new(format!("{}_routing", &params.name), lib.pdk.clone());
     let m0 = lib.pdk.metal(0);
 
-    let src = nand.port("Y").largest_rect(m0).unwrap();
+    let src = nand.port("y").largest_rect(m0).unwrap();
     let dst = inv.port("din").largest_rect(m0).unwrap();
     let mut trace = router.trace(src, 0);
     trace.s_bend(dst, Dir::Horiz);
 
     // Add ports
-    abs.add_port(nand.port("A"));
-    abs.add_port(nand.port("B"));
-    abs.add_port(nand.port("VSS").named("vss0"));
+    abs.add_port(nand.port("a"));
+    abs.add_port(nand.port("b"));
+    abs.add_port(nand.port("vss").named("vss0"));
     abs.add_port(nand.port("vpb").named("vpb0"));
-    abs.add_port(nand.port("VDD").named("vdd0"));
+    abs.add_port(nand.port("vdd").named("vdd0"));
     abs.add_port(nand.port("nsdm").named("nsdm0"));
     abs.add_port(nand.port("psdm").named("psdm0"));
-    abs.add_port(inv.port("gnd").named("vss1"));
+    abs.add_port(inv.port("vss").named("vss1"));
     abs.add_port(inv.port("vdd").named("vdd1"));
     abs.add_port(inv.port("din_b").named("Y"));
     abs.add_port(inv.port("vpb").named("vpb1"));
@@ -93,22 +93,22 @@ pub fn draw_and3(lib: &mut PdkLib, params: AndParams) -> Result<Ptr<Cell>> {
     let mut router = Router::new(format!("{}_routing", &params.name), lib.pdk.clone());
     let m0 = lib.pdk.metal(0);
 
-    let src = nand.port("Y").largest_rect(m0).unwrap();
+    let src = nand.port("y").largest_rect(m0).unwrap();
     let dst = inv.port("din").largest_rect(m0).unwrap();
     let mut trace = router.trace(src, 0);
     trace.s_bend(dst, Dir::Horiz);
 
     // Add ports
-    abs.add_port(nand.port("A"));
-    abs.add_port(nand.port("B"));
-    abs.add_port(nand.port("C"));
-    abs.add_port(nand.port("VSS").named("vss0"));
-    abs.add_port(nand.port("VDD0").named("vdd0"));
-    abs.add_port(nand.port("VDD1").named("vdd1"));
+    abs.add_port(nand.port("a"));
+    abs.add_port(nand.port("b"));
+    abs.add_port(nand.port("c"));
+    abs.add_port(nand.port("vss").named("vss0"));
+    abs.add_port(nand.port("vdd0").named("vdd0"));
+    abs.add_port(nand.port("vdd1").named("vdd1"));
     abs.add_port(nand.port("vpb").named("vpb0"));
     abs.add_port(nand.port("nsdm").named("nsdm0"));
     abs.add_port(nand.port("psdm").named("psdm0"));
-    abs.add_port(inv.port("gnd").named("vss1"));
+    abs.add_port(inv.port("vss").named("vss1"));
     abs.add_port(inv.port("vdd").named("vdd2"));
     abs.add_port(inv.port("din_b").named("Y"));
     abs.add_port(inv.port("vpb").named("vpb1"));
@@ -193,22 +193,22 @@ pub fn draw_nand2(lib: &mut PdkLib, args: GateParams) -> Result<Ptr<Cell>> {
     }
 
     let mut port_vss = ptx.sd_port(0, 0).unwrap();
-    port_vss.set_net("VSS");
+    port_vss.set_net("vss");
     abs.add_port(port_vss);
 
     let mut port_vdd = ptx.sd_port(1, 1).unwrap();
-    port_vdd.set_net("VDD");
+    port_vdd.set_net("vdd");
     abs.add_port(port_vdd);
 
     let mut port_a = ptx.gate_port(0).unwrap();
-    port_a.set_net("A");
+    port_a.set_net("a");
     abs.add_port(port_a);
 
     let mut port_b = ptx.gate_port(1).unwrap();
-    port_b.set_net("B");
+    port_b.set_net("b");
     abs.add_port(port_b);
 
-    let mut port_y = AbstractPort::new("Y");
+    let mut port_y = AbstractPort::new("y");
 
     let rects = [
         Rect {
@@ -294,12 +294,12 @@ pub fn draw_nor2(lib: &mut PdkLib, args: GateParams) -> Result<Ptr<Cell>> {
         xmax -= xshift;
     }
 
-    abs.add_port(ptx.sd_port(0, 0).unwrap().named("VSS"));
-    abs.add_port(ptx.sd_port(1, 2).unwrap().named("VDD"));
-    abs.add_port(ptx.gate_port(0).unwrap().named("A"));
-    abs.add_port(ptx.gate_port(1).unwrap().named("B"));
+    abs.add_port(ptx.sd_port(0, 0).unwrap().named("vss"));
+    abs.add_port(ptx.sd_port(1, 2).unwrap().named("vdd"));
+    abs.add_port(ptx.gate_port(0).unwrap().named("a"));
+    abs.add_port(ptx.gate_port(1).unwrap().named("b"));
 
-    let mut port_y = AbstractPort::new("Y");
+    let mut port_y = AbstractPort::new("y");
 
     let rects = [
         Rect {
@@ -390,17 +390,17 @@ pub fn draw_nand3(lib: &mut PdkLib, args: GateParams) -> Result<Ptr<Cell>> {
     assert!(xmax <= xlim_h);
     assert!(xmin >= xlim_l);
 
-    abs.add_port(ptx.sd_port(0, 0).unwrap().named("VSS"));
-    abs.add_port(ptx.sd_port(1, 1).unwrap().named("VDD0"));
-    abs.add_port(ptx.sd_port(1, 3).unwrap().named("VDD1"));
-    abs.add_port(ptx.gate_port(0).unwrap().named("C"));
-    abs.add_port(ptx.gate_port(1).unwrap().named("B"));
-    abs.add_port(ptx.gate_port(2).unwrap().named("A"));
+    abs.add_port(ptx.sd_port(0, 0).unwrap().named("vss"));
+    abs.add_port(ptx.sd_port(1, 1).unwrap().named("vdd0"));
+    abs.add_port(ptx.sd_port(1, 3).unwrap().named("vdd1"));
+    abs.add_port(ptx.gate_port(0).unwrap().named("c"));
+    abs.add_port(ptx.gate_port(1).unwrap().named("b"));
+    abs.add_port(ptx.gate_port(2).unwrap().named("a"));
     abs.add_port(ptx.merged_vpb_port(1));
     abs.add_port(inst.port("nsdm_0").named("nsdm"));
     abs.add_port(inst.port("psdm_1").named("psdm"));
 
-    let mut port_y = AbstractPort::new("Y");
+    let mut port_y = AbstractPort::new("y");
 
     let rects = [
         Rect::new(Point::new(ny.p0.x, ny.p0.y), Point::new(xmax, ny.p1.y)),
@@ -474,7 +474,7 @@ pub fn draw_inv(lib: &mut PdkLib, args: GateParams) -> Result<Ptr<Cell>> {
     layout.insts.push(inst.clone());
 
     let mut port_vss = ptx.sd_port(0, 0).unwrap();
-    port_vss.set_net("gnd");
+    port_vss.set_net("vss");
     abs.add_port(port_vss);
 
     let mut port_vdd = ptx.sd_port(1, 0).unwrap();

--- a/sramgen/src/layout/latch.rs
+++ b/sramgen/src/layout/latch.rs
@@ -40,8 +40,8 @@ pub fn draw_sr_latch(lib: &mut PdkLib, name: &str) -> Result<Ptr<Cell>> {
     let m0 = cfg.layerkey(0);
     let m1 = cfg.layerkey(1);
 
-    let src = nor2.port("Y").largest_rect(m0).unwrap();
-    let dst = nor1.port("A").largest_rect(m0).unwrap();
+    let src = nor2.port("y").largest_rect(m0).unwrap();
+    let dst = nor1.port("a").largest_rect(m0).unwrap();
     let mut trace = router.trace(src, 0);
     trace
         .place_cursor(Dir::Horiz, false)
@@ -49,8 +49,8 @@ pub fn draw_sr_latch(lib: &mut PdkLib, name: &str) -> Result<Ptr<Cell>> {
         .horiz_to(dst.p0.x)
         .vert_to(dst.p1.y);
 
-    let src = nor1.port("Y").largest_rect(m0).unwrap();
-    let dst = nor2.port("A").largest_rect(m0).unwrap();
+    let src = nor1.port("y").largest_rect(m0).unwrap();
+    let dst = nor2.port("a").largest_rect(m0).unwrap();
     let mut trace = router.trace(src, 0);
     trace
         .place_cursor(Dir::Horiz, false)
@@ -59,13 +59,13 @@ pub fn draw_sr_latch(lib: &mut PdkLib, name: &str) -> Result<Ptr<Cell>> {
         .vert_to(dst.p0.y)
         .contact_down(dst);
 
-    abs.add_port(nor1.port("B").named("set"));
-    abs.add_port(nor2.port("B").named("reset"));
-    abs.add_port(nor1.port("Y").named("q_b"));
-    abs.add_port(nor2.port("Y").named("q"));
+    abs.add_port(nor1.port("b").named("set"));
+    abs.add_port(nor2.port("b").named("reset"));
+    abs.add_port(nor1.port("y").named("q_b"));
+    abs.add_port(nor2.port("y").named("q"));
 
     let width = 3 * cfg.line(1);
-    for port in ["VDD", "VSS"] {
+    for port in ["vdd", "vss"] {
         let src = nor1.port(port).largest_rect(m0).unwrap();
         let src2 = nor2.port(port).largest_rect(m0).unwrap();
         let xspan = Span::from_center_span_gridded(src.center().x, width, cfg.grid());

--- a/sramgen/src/layout/tmc.rs
+++ b/sramgen/src/layout/tmc.rs
@@ -75,8 +75,8 @@ pub fn draw_dbdr_delay_cell(lib: &mut PdkLib, name: &str) -> Result<Ptr<Cell>> {
     let m1 = cfg.layerkey(1);
 
     let src = inv.port("din_b").largest_rect(m0).unwrap();
-    let dst2 = nand2.port("B").largest_rect(m0).unwrap();
-    let dst1 = nand1.port("B").largest_rect(m0).unwrap();
+    let dst2 = nand2.port("b").largest_rect(m0).unwrap();
+    let dst1 = nand1.port("b").largest_rect(m0).unwrap();
     let mut trace = router.trace(src, 0);
     trace
         .place_cursor_centered()
@@ -90,7 +90,7 @@ pub fn draw_dbdr_delay_cell(lib: &mut PdkLib, name: &str) -> Result<Ptr<Cell>> {
     // Join VDD
     let width = 3 * cfg.line(1);
 
-    for (inv_port, nand_port, stack) in [("vdd", "VDD", "ntap"), ("gnd", "VSS", "ptap")] {
+    for (inv_port, nand_port, stack) in [("vdd", "vdd", "ntap"), ("vss", "vss", "ptap")] {
         let dst0 = inv.port(inv_port).largest_rect(m0).unwrap();
         let dst1 = nand1.port(nand_port).largest_rect(m0).unwrap();
         let dst2 = nand2.port(nand_port).largest_rect(m0).unwrap();
@@ -133,10 +133,10 @@ pub fn draw_dbdr_delay_cell(lib: &mut PdkLib, name: &str) -> Result<Ptr<Cell>> {
     }
 
     abs.add_port(inv.port("din").named("clk_in"));
-    abs.add_port(nand1.port("A").named("din"));
-    abs.add_port(nand1.port("Y").named("clk_out"));
-    abs.add_port(nand2.port("A").named("en"));
-    abs.add_port(nand2.port("Y").named("dout"));
+    abs.add_port(nand1.port("a").named("din"));
+    abs.add_port(nand1.port("y").named("clk_out"));
+    abs.add_port(nand2.port("a").named("en"));
+    abs.add_port(nand2.port("y").named("dout"));
 
     layout.add_inst(inv);
     layout.add_inst(nand1);


### PR DESCRIPTION
Since there isn't enough space to place taps between decoder gates,
this commit adds taps to the left and right sides of the decoders.

Some of the pin structure has been changed – in particular, merging of
decoder wells and power pins is done in the decoder generator, rather
than in the top-level SRAM bank generator.
