### PR TITLE
Update rustfmt import granularity settings

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+unstable_features = true
+imports_granularity = "Module"

--- a/sramgen/src/bitcells.rs
+++ b/sramgen/src/bitcells.rs
@@ -1,14 +1,12 @@
 use std::collections::HashMap;
 
-use vlsir::{
-    circuit::{connection::Stype, port::Direction, Connection, Instance, Port, Signal, Slice},
-    Module,
-};
+use vlsir::circuit::connection::Stype;
+use vlsir::circuit::port::Direction;
+use vlsir::circuit::{Connection, Instance, Port, Signal, Slice};
+use vlsir::Module;
 
-use crate::{
-    tech::sram_sp_cell_ref,
-    utils::{sig_conn, signal},
-};
+use crate::tech::sram_sp_cell_ref;
+use crate::utils::{sig_conn, signal};
 
 use serde::{Deserialize, Serialize};
 
@@ -115,7 +113,8 @@ pub fn bitcell_array(params: BitcellArrayParams) -> Module {
 mod tests {
     use vlsir::circuit::Package;
 
-    use crate::{save_bin, tech::all_external_modules};
+    use crate::save_bin;
+    use crate::tech::all_external_modules;
 
     use super::*;
 

--- a/sramgen/src/decoder.rs
+++ b/sramgen/src/decoder.rs
@@ -2,17 +2,14 @@ use std::collections::HashMap;
 
 use fanout::FanoutAnalyzer;
 
-use crate::{
-    gate::{inv, nand2, Gate, GateParams, GateType, Size},
-    utils::{log2, sig_conn, signal, BusConnection},
-};
+use crate::gate::{inv, nand2, Gate, GateParams, GateType, Size};
+use crate::utils::{log2, sig_conn, signal, BusConnection};
 use pdkprims::config::Int;
 use serde::{Deserialize, Serialize};
-use vlsir::{
-    circuit::{connection::Stype, port, Concat, Connection, Instance, Module, Port, Signal, Slice},
-    reference::To,
-    Reference,
-};
+use vlsir::circuit::connection::Stype;
+use vlsir::circuit::{port, Concat, Connection, Instance, Module, Port, Signal, Slice};
+use vlsir::reference::To;
+use vlsir::Reference;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct DecoderTree {

--- a/sramgen/src/dff.rs
+++ b/sramgen/src/dff.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
-use vlsir::circuit::Instance;
-use vlsir::circuit::Module;
+use vlsir::circuit::{Instance, Module};
 
 use crate::tech::openram_dff_ref;
-use crate::utils::port_output;
-use crate::utils::{bus, conns::conn_slice, port_inout, port_input, sig_conn, signal};
+use crate::utils::conns::conn_slice;
+use crate::utils::{bus, port_inout, port_input, port_output, sig_conn, signal};
 
 pub struct DffArrayParams {
     pub name: String,
@@ -66,7 +65,8 @@ pub fn dff_array(params: DffArrayParams) -> Vec<Module> {
 mod tests {
     use vlsir::circuit::Package;
 
-    use crate::{save_bin, tech::all_external_modules};
+    use crate::save_bin;
+    use crate::tech::all_external_modules;
 
     use super::*;
 

--- a/sramgen/src/gate.rs
+++ b/sramgen/src/gate.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 
-use pdkprims::{config::Int, mos::MosType};
+use pdkprims::config::Int;
+use pdkprims::mos::MosType;
 use serde::{Deserialize, Serialize};
 use vlsir::circuit::{port, Instance, Module, Port};
 
-use crate::{
-    mos::Mosfet,
-    utils::{conn_map, local_reference, port_inout, port_input, port_output, sig_conn, signal},
+use crate::mos::Mosfet;
+use crate::utils::{
+    conn_map, local_reference, port_inout, port_input, port_output, sig_conn, signal,
 };
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]

--- a/sramgen/src/layout/array.rs
+++ b/sramgen/src/layout/array.rs
@@ -1,12 +1,11 @@
 use layout21::raw::geom::Dir;
-use layout21::raw::{Abstract, Int};
-use layout21::{
-    raw::{Cell, Instance, Layout, Point},
-    utils::Ptr,
-};
+use layout21::raw::{Abstract, Cell, Instance, Int, Layout, Point};
+use layout21::utils::Ptr;
 use pdkprims::PdkLib;
 
-use crate::{bbox, layout::grid::GridCells, tech::*};
+use crate::bbox;
+use crate::layout::grid::GridCells;
+use crate::tech::*;
 use serde::{Deserialize, Serialize};
 
 use super::Result;

--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -1,11 +1,8 @@
 use derive_builder::Builder;
 use layout21::raw::align::AlignRect;
 use layout21::raw::geom::Rect;
-use layout21::raw::{AbstractPort, Dir, Int};
-use layout21::{
-    raw::{BoundBoxTrait, Cell, Instance, Layout, Point, Span},
-    utils::Ptr,
-};
+use layout21::raw::{AbstractPort, BoundBoxTrait, Cell, Dir, Instance, Int, Layout, Point, Span};
+use layout21::utils::Ptr;
 use pdkprims::bus::{ContactPolicy, ContactPosition};
 use pdkprims::{LayerIdx, PdkLib};
 
@@ -22,16 +19,14 @@ use crate::layout::route::Router;
 use crate::layout::tmc::{draw_tmc, TmcParams};
 use crate::tech::{BITCELL_HEIGHT, COLUMN_WIDTH};
 
+use super::array::draw_array;
+use super::decoder::{draw_inv_dec_array, draw_nand2_dec_array};
+use super::dff::draw_dff_array;
+use super::mux::{draw_read_mux_array, draw_write_mux_array};
+use super::precharge::draw_precharge_array;
 use super::route::Trace;
-use super::{
-    array::draw_array,
-    decoder::{draw_inv_dec_array, draw_nand2_dec_array},
-    dff::draw_dff_array,
-    mux::{draw_read_mux_array, draw_write_mux_array},
-    precharge::draw_precharge_array,
-    sense_amp::draw_sense_amp_array,
-    Result,
-};
+use super::sense_amp::draw_sense_amp_array;
+use super::Result;
 
 pub const M1_PWR_OVERHANG: Int = 200;
 

--- a/sramgen/src/layout/common.rs
+++ b/sramgen/src/layout/common.rs
@@ -1,11 +1,10 @@
 use derive_builder::Builder;
 use layout21::raw::align::AlignRect;
 use layout21::raw::geom::Dir;
-use layout21::raw::{AbstractPort, BoundBox, BoundBoxTrait, Element, Int, LayerKey, Rect};
-use layout21::{
-    raw::{Cell, Instance},
-    utils::Ptr,
+use layout21::raw::{
+    AbstractPort, BoundBox, BoundBoxTrait, Cell, Element, Instance, Int, LayerKey, Rect,
 };
+use layout21::utils::Ptr;
 use pdkprims::config::Uint;
 use pdkprims::contact::ContactParams;
 use pdkprims::PdkLib;

--- a/sramgen/src/layout/dff.rs
+++ b/sramgen/src/layout/dff.rs
@@ -1,10 +1,8 @@
-use crate::{layout::Result, tech::openram_dff_gds};
+use crate::layout::Result;
+use crate::tech::openram_dff_gds;
 use layout21::raw::translate::Translate;
-use layout21::raw::{Abstract, Instance, Layout, Point};
-use layout21::{
-    raw::{Cell, Dir},
-    utils::Ptr,
-};
+use layout21::raw::{Abstract, Cell, Dir, Instance, Layout, Point};
+use layout21::utils::Ptr;
 use pdkprims::PdkLib;
 
 use crate::layout::array::*;

--- a/sramgen/src/layout/gate.rs
+++ b/sramgen/src/layout/gate.rs
@@ -2,15 +2,12 @@ use crate::gate::{GateParams, Size};
 use crate::layout::Result;
 use layout21::raw::align::AlignRect;
 use layout21::raw::geom::Dir;
-use layout21::raw::BoundBoxTrait;
-use layout21::{
-    raw::{Abstract, AbstractPort, Cell, Instance, Layout, Point, Rect, Shape},
-    utils::Ptr,
+use layout21::raw::{
+    Abstract, AbstractPort, BoundBoxTrait, Cell, Instance, Layout, Point, Rect, Shape,
 };
-use pdkprims::{
-    mos::{Intent, MosDevice, MosParams, MosType},
-    PdkLib,
-};
+use layout21::utils::Ptr;
+use pdkprims::mos::{Intent, MosDevice, MosParams, MosType};
+use pdkprims::PdkLib;
 
 use super::draw_rect;
 use super::route::Router;

--- a/sramgen/src/layout/mod.rs
+++ b/sramgen/src/layout/mod.rs
@@ -1,7 +1,5 @@
-use layout21::{
-    raw::{Cell, Element, Instance, LayerKey, LayerPurpose, Layout, Point, Rect, Shape},
-    utils::Ptr,
-};
+use layout21::raw::{Cell, Element, Instance, LayerKey, LayerPurpose, Layout, Point, Rect, Shape};
+use layout21::utils::Ptr;
 use pdkprims::PdkLib;
 
 use crate::tech::sram_sp_cell_gds;

--- a/sramgen/src/layout/mux.rs
+++ b/sramgen/src/layout/mux.rs
@@ -1,15 +1,13 @@
 use anyhow::anyhow;
 use layout21::raw::align::AlignRect;
 use layout21::raw::geom::Dir;
-use layout21::raw::{Abstract, AbstractPort, Element, Int, Rect, Shape, Span, TransformTrait};
-use layout21::{
-    raw::{BoundBoxTrait, Cell, Instance, Layout, Point},
-    utils::Ptr,
+use layout21::raw::{
+    Abstract, AbstractPort, BoundBoxTrait, Cell, Element, Instance, Int, Layout, Point, Rect,
+    Shape, Span, TransformTrait,
 };
-use pdkprims::{
-    mos::{Intent, MosDevice, MosParams, MosType},
-    PdkLib,
-};
+use layout21::utils::Ptr;
+use pdkprims::mos::{Intent, MosDevice, MosParams, MosType};
+use pdkprims::PdkLib;
 
 use crate::layout::array::*;
 use crate::layout::route::grid::{Grid, TrackLocator};

--- a/sramgen/src/layout/precharge.rs
+++ b/sramgen/src/layout/precharge.rs
@@ -1,16 +1,12 @@
 use layout21::raw::align::AlignRect;
 use layout21::raw::geom::Dir;
 use layout21::raw::{
-    Abstract, AbstractPort, BoundBox, BoundBoxTrait, Rect, Shape, Span, TransformTrait,
+    Abstract, AbstractPort, BoundBox, BoundBoxTrait, Cell, Instance, Layout, Point, Rect, Shape,
+    Span, TransformTrait,
 };
-use layout21::{
-    raw::{Cell, Instance, Layout, Point},
-    utils::Ptr,
-};
-use pdkprims::{
-    mos::{Intent, MosDevice, MosParams, MosType},
-    PdkLib,
-};
+use layout21::utils::Ptr;
+use pdkprims::mos::{Intent, MosDevice, MosParams, MosType};
+use pdkprims::PdkLib;
 
 use super::array::*;
 use super::common::{draw_two_level_contact, TwoLevelContactParams};

--- a/sramgen/src/layout/route/mod.rs
+++ b/sramgen/src/layout/route/mod.rs
@@ -1,14 +1,11 @@
-use pdkprims::{contact::ContactParams, LayerIdx, Pdk};
+use pdkprims::contact::ContactParams;
+use pdkprims::{LayerIdx, Pdk};
 
 use std::sync::Arc;
 
-use layout21::{
-    raw::{
-        align::AlignRect, BoundBoxTrait, Cell, Dir, Instance, Int, LayerKey, Layout, Point, Rect,
-        Span,
-    },
-    utils::Ptr,
-};
+use layout21::raw::align::AlignRect;
+use layout21::raw::{BoundBoxTrait, Cell, Dir, Instance, Int, LayerKey, Layout, Point, Rect, Span};
+use layout21::utils::Ptr;
 
 pub enum VertDir {
     Above,

--- a/sramgen/src/layout/sense_amp.rs
+++ b/sramgen/src/layout/sense_amp.rs
@@ -3,7 +3,8 @@ use layout21::raw::geom::Dir;
 use pdkprims::PdkLib;
 
 use super::array::*;
-use crate::{tech::sramgen_sp_sense_amp_gds, Result};
+use crate::tech::sramgen_sp_sense_amp_gds;
+use crate::Result;
 
 pub fn draw_sense_amp_array(lib: &mut PdkLib, width: usize) -> Result<ArrayedCell> {
     let sa = sramgen_sp_sense_amp_gds(lib)?;

--- a/sramgen/src/lib.rs
+++ b/sramgen/src/lib.rs
@@ -1,11 +1,10 @@
 use std::path::PathBuf;
 
 use decoder::DecoderTree;
-use layout21::{
-    raw::{BoundBox, Cell},
-    utils::Ptr,
-};
-use vlsir::{circuit::Package, spice::SimInput};
+use layout21::raw::{BoundBox, Cell};
+use layout21::utils::Ptr;
+use vlsir::circuit::Package;
+use vlsir::spice::SimInput;
 
 pub mod bitcells;
 pub mod decoder;

--- a/sramgen/src/mos.rs
+++ b/sramgen/src/mos.rs
@@ -1,15 +1,12 @@
 use std::collections::HashMap;
 
-use pdkprims::{config::Int, mos::MosType};
+use pdkprims::config::Int;
+use pdkprims::mos::MosType;
 use serde::{Deserialize, Serialize};
-use vlsir::{
-    circuit::{
-        parameter_value::Value, port, Connection, ExternalModule, Instance, Parameter,
-        ParameterValue, Port,
-    },
-    reference::To,
-    QualifiedName, Reference,
-};
+use vlsir::circuit::parameter_value::Value;
+use vlsir::circuit::{port, Connection, ExternalModule, Instance, Parameter, ParameterValue, Port};
+use vlsir::reference::To;
+use vlsir::{QualifiedName, Reference};
 
 use crate::utils::signal;
 

--- a/sramgen/src/mux.rs
+++ b/sramgen/src/mux.rs
@@ -1,13 +1,15 @@
 use std::collections::HashMap;
 
-use pdkprims::{config::Int, mos::MosType};
+use pdkprims::config::Int;
+use pdkprims::mos::MosType;
 
-use vlsir::{circuit::Module, reference::To, Reference};
+use vlsir::circuit::Module;
+use vlsir::reference::To;
+use vlsir::Reference;
 
-use crate::{
-    mos::Mosfet,
-    utils::{bus, conn_map, conns::conn_slice, port_inout, port_input, sig_conn, signal},
-};
+use crate::mos::Mosfet;
+use crate::utils::conns::conn_slice;
+use crate::utils::{bus, conn_map, port_inout, port_input, sig_conn, signal};
 
 pub struct ColumnMuxParams {
     pub length: Int,
@@ -416,7 +418,9 @@ pub fn column_mux_4(params: ColumnMuxParams) -> Module {
 mod tests {
     use vlsir::circuit::Package;
 
-    use crate::{save_bin, tech::all_external_modules, utils::save_modules};
+    use crate::save_bin;
+    use crate::tech::all_external_modules;
+    use crate::utils::save_modules;
 
     use super::*;
 

--- a/sramgen/src/netlist.rs
+++ b/sramgen/src/netlist.rs
@@ -1,11 +1,11 @@
-use std::{collections::HashMap, fs::File, path::Path};
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::Path;
 
-use vlsir::{
-    circuit::{Instance, Package},
-    reference::To,
-    spice::SimInput,
-    Module,
-};
+use vlsir::circuit::{Instance, Package};
+use vlsir::reference::To;
+use vlsir::spice::SimInput;
+use vlsir::Module;
 
 pub const PRIMITIVE_DOMAIN: &str = "primitives";
 
@@ -117,12 +117,11 @@ impl NetlistWriter<std::fs::File> {
 #[cfg(test)]
 mod tests {
 
-    use vlsir::{circuit::Package, spice::SimInput};
+    use vlsir::circuit::Package;
+    use vlsir::spice::SimInput;
 
-    use crate::{
-        decoder::{hierarchical_decoder, DecoderParams, DecoderTree},
-        mos::{ext_nmos, ext_pmos},
-    };
+    use crate::decoder::{hierarchical_decoder, DecoderParams, DecoderTree};
+    use crate::mos::{ext_nmos, ext_pmos};
 
     use super::Result;
 

--- a/sramgen/src/precharge.rs
+++ b/sramgen/src/precharge.rs
@@ -1,17 +1,15 @@
 use std::collections::HashMap;
 
-use pdkprims::{config::Int, mos::MosType};
+use pdkprims::config::Int;
+use pdkprims::mos::MosType;
 
-use vlsir::{
-    circuit::{connection::Stype, Connection, Module, Slice},
-    reference::To,
-    Reference,
-};
+use vlsir::circuit::connection::Stype;
+use vlsir::circuit::{Connection, Module, Slice};
+use vlsir::reference::To;
+use vlsir::Reference;
 
-use crate::{
-    mos::Mosfet,
-    utils::{bus, port_inout, port_input, sig_conn, signal},
-};
+use crate::mos::Mosfet;
+use crate::utils::{bus, port_inout, port_input, sig_conn, signal};
 
 #[derive(Debug, Clone)]
 pub struct PrechargeParams {
@@ -161,7 +159,8 @@ pub fn precharge(params: PrechargeParams) -> Module {
 mod tests {
     use vlsir::circuit::Package;
 
-    use crate::{save_bin, tech::all_external_modules};
+    use crate::save_bin;
+    use crate::tech::all_external_modules;
 
     use super::*;
 

--- a/sramgen/src/rbl.rs
+++ b/sramgen/src/rbl.rs
@@ -3,11 +3,10 @@ use std::collections::HashMap;
 use vlsir::circuit::{Instance, Module};
 
 use crate::gate::{inv, GateParams, Size};
-use crate::precharge::precharge;
+use crate::precharge::{precharge, PrechargeParams};
 use crate::tech::sram_sp_replica_cell_ref;
-use crate::{
-    precharge::PrechargeParams,
-    utils::{conn_map, local_reference, port_inout, port_input, port_output, sig_conn, signal},
+use crate::utils::{
+    conn_map, local_reference, port_inout, port_input, port_output, sig_conn, signal,
 };
 
 #[derive(Debug, Clone)]

--- a/sramgen/src/sense_amp.rs
+++ b/sramgen/src/sense_amp.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
-use vlsir::{circuit::Instance, Module};
+use vlsir::circuit::Instance;
+use vlsir::Module;
 
-use crate::{
-    tech::sramgen_sp_sense_amp_ref,
-    utils::{bus, conns::conn_slice, port_inout, port_input, port_output, sig_conn, signal},
-};
+use crate::tech::sramgen_sp_sense_amp_ref;
+use crate::utils::conns::conn_slice;
+use crate::utils::{bus, port_inout, port_input, port_output, sig_conn, signal};
 
 use serde::{Deserialize, Serialize};
 
@@ -68,7 +68,8 @@ pub fn sense_amp_array(params: SenseAmpArrayParams) -> Module {
 mod tests {
     use vlsir::circuit::Package;
 
-    use crate::{save_bin, tech::all_external_modules};
+    use crate::save_bin;
+    use crate::tech::all_external_modules;
 
     use super::*;
 

--- a/sramgen/src/sram.rs
+++ b/sramgen/src/sram.rs
@@ -2,23 +2,21 @@ use std::collections::HashMap;
 
 use vlsir::circuit::{Instance, Module};
 
-use crate::{
-    bitcells::{bitcell_array, BitcellArrayParams},
-    decoder::{hierarchical_decoder, DecoderParams, DecoderTree},
-    dff::dff_array,
-    gate::Size,
-    mux::{
-        column_read_mux_2_array, column_write_mux_2_array, ColumnMuxArrayParams, ColumnMuxParams,
-    },
-    precharge::{precharge_array, PrechargeArrayParams, PrechargeParams},
-    sense_amp::{sense_amp_array, SenseAmpArrayParams},
-    utils::{
-        bus, conn_map, conns::conn_slice, local_reference, port_inout, port_input, port_output,
-        sig_conn, signal,
-    },
-    wl_driver::{wordline_driver_array, WordlineDriverArrayParams, WordlineDriverParams},
-    write_driver::{bitline_driver_array, BitlineDriverArrayParams, BitlineDriverParams},
+use crate::bitcells::{bitcell_array, BitcellArrayParams};
+use crate::decoder::{hierarchical_decoder, DecoderParams, DecoderTree};
+use crate::dff::dff_array;
+use crate::gate::Size;
+use crate::mux::{
+    column_read_mux_2_array, column_write_mux_2_array, ColumnMuxArrayParams, ColumnMuxParams,
 };
+use crate::precharge::{precharge_array, PrechargeArrayParams, PrechargeParams};
+use crate::sense_amp::{sense_amp_array, SenseAmpArrayParams};
+use crate::utils::conns::conn_slice;
+use crate::utils::{
+    bus, conn_map, local_reference, port_inout, port_input, port_output, sig_conn, signal,
+};
+use crate::wl_driver::{wordline_driver_array, WordlineDriverArrayParams, WordlineDriverParams};
+use crate::write_driver::{bitline_driver_array, BitlineDriverArrayParams, BitlineDriverParams};
 
 use crate::dff::DffArrayParams;
 

--- a/sramgen/src/tech/sky130.rs
+++ b/sramgen/src/tech/sky130.rs
@@ -1,17 +1,16 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
+use std::path::PathBuf;
 
-use layout21::{
-    gds21::GdsLibrary,
-    raw::{Cell, Library},
-    utils::Ptr,
-};
+use layout21::gds21::GdsLibrary;
+use layout21::raw::{Cell, Library};
+use layout21::utils::Ptr;
 use pdkprims::PdkLib;
-use vlsir::{circuit::ExternalModule, reference::To, QualifiedName, Reference};
+use vlsir::circuit::ExternalModule;
+use vlsir::reference::To;
+use vlsir::{QualifiedName, Reference};
 
-use crate::{
-    mos::{ext_nmos, ext_pmos},
-    utils::simple_ext_module,
-};
+use crate::mos::{ext_nmos, ext_pmos};
+use crate::utils::simple_ext_module;
 
 pub const SKY130_DOMAIN: &str = "sky130";
 pub const SRAM_SP_CELL: &str = "sram_sp_cell";

--- a/sramgen/src/utils.rs
+++ b/sramgen/src/utils.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
 
-use vlsir::{
-    circuit::{connection::Stype, port, Connection, ExternalModule, Port, Signal, Slice},
-    reference::To,
-    Module, QualifiedName, Reference,
-};
+use vlsir::circuit::connection::Stype;
+use vlsir::circuit::{port, Connection, ExternalModule, Port, Signal, Slice};
+use vlsir::reference::To;
+use vlsir::{Module, QualifiedName, Reference};
 
 use crate::save_bin;
 use crate::tech::all_external_modules;
@@ -77,7 +76,8 @@ pub fn port_output(s: &Signal) -> Port {
 }
 
 pub mod conns {
-    use vlsir::circuit::{connection::Stype, Concat, Connection, Signal, Slice};
+    use vlsir::circuit::connection::Stype;
+    use vlsir::circuit::{Concat, Connection, Signal, Slice};
 
     pub fn get_sig(s: &Signal, idx: usize) -> Option<Slice> {
         let idx = idx as i64;

--- a/sramgen/src/wl_driver.rs
+++ b/sramgen/src/wl_driver.rs
@@ -6,12 +6,10 @@ use pdkprims::config::Int;
 
 use vlsir::circuit::{Instance, Module};
 
-use crate::{
-    gate::{and2, AndParams, Size},
-    utils::{
-        bus, conn_map, conns::conn_slice, local_reference, port_inout, port_input, port_output,
-        sig_conn, signal,
-    },
+use crate::gate::{and2, AndParams, Size};
+use crate::utils::conns::conn_slice;
+use crate::utils::{
+    bus, conn_map, local_reference, port_inout, port_input, port_output, sig_conn, signal,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]

--- a/sramgen/src/write_driver.rs
+++ b/sramgen/src/write_driver.rs
@@ -1,13 +1,15 @@
 use std::collections::HashMap;
 
-use pdkprims::{config::Int, mos::MosType};
+use pdkprims::config::Int;
+use pdkprims::mos::MosType;
 
-use vlsir::{circuit::Module, reference::To, Reference};
+use vlsir::circuit::Module;
+use vlsir::reference::To;
+use vlsir::Reference;
 
-use crate::{
-    mos::Mosfet,
-    utils::{bus, conns::conn_slice, port_inout, port_input, sig_conn, signal},
-};
+use crate::mos::Mosfet;
+use crate::utils::conns::conn_slice;
+use crate::utils::{bus, port_inout, port_input, sig_conn, signal};
 
 pub struct BitlineDriverParams {
     pub length: Int,
@@ -134,7 +136,8 @@ pub fn bitline_driver(params: BitlineDriverParams) -> Module {
 mod tests {
     use vlsir::circuit::Package;
 
-    use crate::{save_bin, tech::all_external_modules};
+    use crate::save_bin;
+    use crate::tech::all_external_modules;
 
     use super::*;
 


### PR DESCRIPTION
Add a rustfmt.toml file specifying that the import granularity
should be at the module level. Note that this feature is currently
unstable, so you will need a nightly version of Rust to run rustfmt.

Once a nightly version of Rust is installed, run the formatter
by running `cargo +nightly fmt` in the `sram22/` directory.
