### PR TITLE
Fix routing of data to column inverters

### DIFF
--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -429,7 +429,9 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
             .vert_to(dst1.top())
             .down()
             .down()
-            .down();
+            .down()
+            .set_min_width()
+            .horiz_to(dst1.left());
 
         let mut trace = router.trace(rect, 3);
         trace


### PR DESCRIPTION
Fixes an issue where the data wire on M3 was not actually connected
to the column inverter input pin on local interconnect / M0.
