### PR TITLE
Fix most DRC issues in SRAM peripherals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,7 +818,7 @@ checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 [[package]]
 name = "pdkprims"
 version = "0.0.1"
-source = "git+https://github.com/rahulk29/pdkprims.git?branch=master#4bfe67280cc80f3e4489ed9f459caaba9a4544a1"
+source = "git+https://github.com/rahulk29/pdkprims.git?branch=master#4c0e8edd86cc07518957f28072394849eeb5223a"
 dependencies = [
  "arcstr",
  "derive_builder 0.11.2",

--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -139,7 +139,7 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
     nand_dec.align_to_the_left_of(inv_dec.bbox(), 1_000);
     nand_dec.align_centers_vertically_gridded(core_bbox, grid);
 
-    pc.align_beneath(core_bbox, 1_000);
+    pc.align_beneath(core_bbox, 1_270);
     pc.align_centers_horizontally_gridded(core_bbox, grid);
 
     read_mux.align_beneath(pc.bbox(), 1_000);

--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -561,7 +561,7 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
     layout.insts.push(sense_amp);
     layout.insts.push(dffs);
     layout.insts.push(addr_dffs);
-    layout.insts.push(tmc);
+    // layout.insts.push(tmc);
 
     let bbox = layout.bbox();
     let routing = router.finish();
@@ -569,7 +569,7 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
 
     power_grid.set_enclosure(bbox);
     power_grid.add_blockage(2, core_bbox.into_rect());
-    layout.insts.push(power_grid.generate()?);
+    // layout.insts.push(power_grid.generate()?);
 
     let guard_ring = draw_guard_ring(
         lib,

--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -528,7 +528,7 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
                 )
             };
             let mut target = target_port.largest_rect(m1).unwrap();
-            let base = target.p0.y + 160 + 420 * (2 * target_idx + idx % 2) as isize;
+            let base = target.p0.y + 160 + 600 * (2 * target_idx + idx % 2) as isize;
             let top = base + 320;
             assert!(top <= target.p1.y);
             target.p0.y = base;

--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -160,7 +160,7 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
     decoder1.align_beneath(core_bbox, 1_000);
     decoder1.align_to_the_left_of(sense_amp.bbox(), 1_000);
 
-    decoder2.align_beneath(decoder1.bbox(), 1_000);
+    decoder2.align_beneath(decoder1.bbox(), 1_270);
     decoder2.align_to_the_left_of(sense_amp.bbox(), 1_000);
 
     addr_dffs.align_top(decoder2.bbox());

--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -517,16 +517,19 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
                 .horiz_to_trace(&traces[idx])
                 .contact_down(traces[idx].rect());
 
-            let target_port = if i < decoder1_bits {
+            let (target_port, target_idx) = if i < decoder1_bits {
                 // Route to decoder1
-                decoder1.port(format!("{}_{}", addr_prefix, i))
+                (decoder1.port(format!("{}_{}", addr_prefix, i)), i)
             } else {
                 // Route to decoder2
-                decoder2.port(format!("{}_{}", addr_prefix, i - decoder1_bits))
+                (
+                    decoder2.port(format!("{}_{}", addr_prefix, i - decoder1_bits)),
+                    i - decoder1_bits,
+                )
             };
             let mut target = target_port.largest_rect(m1).unwrap();
-            let base = target.p0.y + 200 + 400 * idx as isize;
-            let top = base + 400;
+            let base = target.p0.y + 160 + 420 * (2 * target_idx + idx % 2) as isize;
+            let top = base + 320;
             assert!(top <= target.p1.y);
             target.p0.y = base;
             target.p1.y = top;

--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -129,7 +129,7 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
 
     let core_bbox = core.bbox();
 
-    wldrv_inv.align_to_the_left_of(core_bbox, 1_000);
+    wldrv_inv.align_to_the_left_of(core_bbox, 1_270);
     wldrv_inv.align_centers_vertically_gridded(core_bbox, grid);
     wldrv_nand.align_to_the_left_of(wldrv_inv.bbox(), 1_000);
     wldrv_nand.align_centers_vertically_gridded(core_bbox, grid);

--- a/sramgen/src/layout/decoder.rs
+++ b/sramgen/src/layout/decoder.rs
@@ -583,7 +583,7 @@ fn draw_hier_decode_node(
         1,
         cfg.line(1),
         ContactPolicy {
-            above: Some(ContactPosition::CenteredNonAdjacent),
+            above: Some(ContactPosition::CenteredAdjacent),
             below: Some(ContactPosition::CenteredNonAdjacent),
         },
     );

--- a/sramgen/src/layout/mux.rs
+++ b/sramgen/src/layout/mux.rs
@@ -6,6 +6,7 @@ use layout21::raw::{
     Shape, Span, TransformTrait,
 };
 use layout21::utils::Ptr;
+use pdkprims::bus::{ContactPolicy, ContactPosition};
 use pdkprims::mos::{Intent, MosDevice, MosParams, MosType};
 use pdkprims::PdkLib;
 
@@ -424,9 +425,10 @@ pub fn draw_write_mux_array(lib: &mut PdkLib, width: usize) -> Result<Ptr<Cell>>
     tap_inst.align_centers_gridded(core_inst.bbox(), lib.pdk.grid());
 
     let mut router = Router::new("write_mux_array_route", lib.pdk.clone());
-    let m0 = router.cfg().layerkey(0);
-    let m1 = router.cfg().layerkey(1);
-    let m2 = router.cfg().layerkey(2);
+    let cfg = router.cfg();
+    let m0 = cfg.layerkey(0);
+    let m1 = cfg.layerkey(1);
+    let m2 = cfg.layerkey(2);
 
     let mut span = Span::new(0, 0);
 
@@ -483,9 +485,17 @@ pub fn draw_write_mux_array(lib: &mut PdkLib, width: usize) -> Result<Ptr<Cell>>
     let tc = tc.read().unwrap();
 
     // Route gate signals
+    let space = lib.pdk.bus_min_spacing(
+        2,
+        cfg.line(2),
+        ContactPolicy {
+            above: Some(ContactPosition::CenteredNonAdjacent),
+            below: Some(ContactPosition::CenteredNonAdjacent),
+        },
+    );
     let grid = Grid::builder()
         .line(tc.layer("m2").width)
-        .space(tc.layer("m2").space)
+        .space(space)
         .center(Point::zero())
         .grid(tc.grid)
         .build()?;

--- a/sramgen/src/layout/precharge.rs
+++ b/sramgen/src/layout/precharge.rs
@@ -240,8 +240,8 @@ pub fn draw_precharge_array(lib: &mut PdkLib, width: usize) -> Result<Ptr<Cell>>
         .port_name("vpb")
         .top_overhang(NWELL_COL_VERT_EXTEND)
         .bot_overhang(NWELL_COL_VERT_EXTEND)
-        .left_overhang(NWELL_COL_SIDE_EXTEND)
-        .right_overhang(NWELL_COL_SIDE_EXTEND)
+        .left_overhang(NWELL_COL_SIDE_EXTEND + 200)
+        .right_overhang(NWELL_COL_SIDE_EXTEND + 200)
         .build()?
         .element();
     layout.add(elt);


### PR DESCRIPTION
- Increase spacing between decoders 1 and 2
- Move precharge circuitry farther from SRAM array
- hack: temporarily remove tmc, power strap from bank
- Move wordline drivers farther from SRAM array
- Extend nwell beyond precharge tap cells
- Update pdkprims to version with merged psdm boxes
- Fix spacing DRC issues on decoder connections
- Increase decoder wire spacing
- Increase write mux gate signal spacing
