### PR TITLE
Add top level power ports (VDD and VSS)

### DIFF
--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -1098,6 +1098,9 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
         }
     }
 
+    cell.add_pin("vdd", m2, guard_ring.vdd_ring.top());
+    cell.add_pin("vss", m2, guard_ring.vss_ring.top());
+
     let routing = router.finish();
 
     cell.layout_mut().add_inst(straps.instance);


### PR DESCRIPTION
Located at top of the SRAM guard ring.
