### PR TITLE
LVS clean 32x32 and 16x16 SRAMs

### DIFF
--- a/sramgen/lib/sram_sp_cell/sky130_fd_bd_sram__sram_sp_cell.lvs.spice
+++ b/sramgen/lib/sram_sp_cell/sky130_fd_bd_sram__sram_sp_cell.lvs.spice
@@ -12,6 +12,6 @@ X7 VSS Q QB VNB sky130_fd_pr__special_nfet_latch ad=0p pd=0u as=0p ps=0u w=21000
 .ends
 
 .subckt sky130_fd_bd_sram__sram_sp_colend BL1 VPWR VGND BL0 VNB VPB
-X0 BL1 VNB BL1 VNB sky130_fd_pr__special_nfet_pass ad=1.68e+10p pd=520000u as=0p ps=0u w=0.14 l=0.14
+X0 BL0 VNB BL0 VNB sky130_fd_pr__special_nfet_pass ad=1.68e+10p pd=520000u as=0p ps=0u w=0.14 l=0.14
 .ends
 

--- a/sramgen/lib/sram_sp_cell/sky130_fd_bd_sram__sram_sp_cell.lvs.spice
+++ b/sramgen/lib/sram_sp_cell/sky130_fd_bd_sram__sram_sp_cell.lvs.spice
@@ -12,6 +12,6 @@ X7 VSS Q QB VNB sky130_fd_pr__special_nfet_latch ad=0p pd=0u as=0p ps=0u w=21000
 .ends
 
 .subckt sky130_fd_bd_sram__sram_sp_colend BL1 VPWR VGND BL0 VNB VPB
-X0 BL0 VNB BL0 VNB sky130_fd_pr__special_nfet_pass ad=1.68e+10p pd=520000u as=0p ps=0u w=0.14 l=0.14
+X0 BL1 VNB BL1 VNB sky130_fd_pr__special_nfet_pass ad=1.68e+10p pd=520000u as=0p ps=0u w=0.14 l=0.14
 .ends
 

--- a/sramgen/lib/sramgen_sp_sense_amp/sramgen_sp_sense_amp.spice
+++ b/sramgen/lib/sramgen_sp_sense_amp/sramgen_sp_sense_amp.spice
@@ -60,7 +60,7 @@ mN0 D G S B pshort m=2 w=2.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0
 * Cell Name:    AAA_Comp_SA_sense
 * View Name:    schematic
 ************************************************************************
-.SUBCKT AAA_Comp_SA_sense clk inn inp midn midp outn outp VDD VSS
+.SUBCKT sramgen_sp_sense_amp clk inn inp midn midp outn outp VDD VSS
 *.PININFO clk:I inn:I inp:I midn:O midp:O outn:O outp:O VDD:B VSS:B
 XXTAIL VSS tail clk VSS / nmos4_standard_pcell_0
 XXNFBP VSS outp outn midp / nmos4_standard_pcell_1

--- a/sramgen/lib/sramgen_sp_sense_amp/sramgen_sp_sense_amp.spice
+++ b/sramgen/lib/sramgen_sp_sense_amp/sramgen_sp_sense_amp.spice
@@ -10,13 +10,13 @@
 
 .SUBCKT sramgen_sp_sense_amp clk inn inp outn outp VDD VSS
 *.PININFO clk:I inn:I inp:I midn:O midp:O outn:O outp:O VDD:B VSS:B
-XSWOP outp clk VDD VDD sky130_fd_pr__pfet_01v8 m=1 w=1.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XSWON outn clk VDD VDD sky130_fd_pr__pfet_01v8 m=1 w=1.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XSWMP midp clk VDD VDD sky130_fd_pr__pfet_01v8 m=1 w=1.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XSWMN midn clk VDD VDD sky130_fd_pr__pfet_01v8 m=1 w=1.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
+XSWOP outp clk VDD VDD sky130_fd_pr__pfet_01v8 m=2 w=1.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
+XSWON outn clk VDD VDD sky130_fd_pr__pfet_01v8 m=2 w=1.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
+XSWMP midp clk VDD VDD sky130_fd_pr__pfet_01v8 m=2 w=1.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
+XSWMN midn clk VDD VDD sky130_fd_pr__pfet_01v8 m=2 w=1.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
 XPFBP outp outn VDD VDD sky130_fd_pr__pfet_01v8 m=2 w=2.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
 XPFBN outn outp VDD VDD sky130_fd_pr__pfet_01v8 m=2 w=2.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XTAIL tail clk VSS VSS sky130_fd_pr__nfet_01v8 m=2 w=1.68 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
+XTAIL tail clk VSS VSS sky130_fd_pr__nfet_01v8 m=4 w=1.68 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
 XNFBP outp outn midp VSS sky130_fd_pr__nfet_01v8 m=2 w=1.68 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
 XNFBN outn outp midn VSS sky130_fd_pr__nfet_01v8 m=2 w=1.68 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
 XINP midn inp tail VSS sky130_fd_pr__nfet_01v8 m=2 w=1.68 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 

--- a/sramgen/lib/sramgen_sp_sense_amp/sramgen_sp_sense_amp.spice
+++ b/sramgen/lib/sramgen_sp_sense_amp/sramgen_sp_sense_amp.spice
@@ -1,25 +1,76 @@
-* SRAM sense amplifier
 ************************************************************************
 * auCdl Netlist:
 * 
-* Library Name:  AAA_Comp_SA
+* Library Name:  AAA_Comp_SA_layers
 * Top Cell Name: AAA_Comp_SA_sense
 * View Name:     schematic
-* Netlisted on:  Mar 16 00:39:41 2022
+* Netlisted on:  Nov  1 17:24:53 2022
 ************************************************************************
-
-.SUBCKT sramgen_sp_sense_amp clk inn inp outn outp VDD VSS
-*.PININFO clk:I inn:I inp:I midn:O midp:O outn:O outp:O VDD:B VSS:B
-XSWOP outp clk VDD VDD sky130_fd_pr__pfet_01v8 m=2 w=1.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XSWON outn clk VDD VDD sky130_fd_pr__pfet_01v8 m=2 w=1.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XSWMP midp clk VDD VDD sky130_fd_pr__pfet_01v8 m=2 w=1.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XSWMN midn clk VDD VDD sky130_fd_pr__pfet_01v8 m=2 w=1.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XPFBP outp outn VDD VDD sky130_fd_pr__pfet_01v8 m=2 w=2.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XPFBN outn outp VDD VDD sky130_fd_pr__pfet_01v8 m=2 w=2.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XTAIL tail clk VSS VSS sky130_fd_pr__nfet_01v8 m=4 w=1.68 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XNFBP outp outn midp VSS sky130_fd_pr__nfet_01v8 m=2 w=1.68 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XNFBN outn outp midn VSS sky130_fd_pr__nfet_01v8 m=2 w=1.68 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XINP midn inp tail VSS sky130_fd_pr__nfet_01v8 m=2 w=1.68 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
-XINN midp inn tail VSS sky130_fd_pr__nfet_01v8 m=2 w=1.68 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
+*.BIPOLAR
+*.RESI = 2000 
+*.RESVAL
+*.CAPVAL
+*.DIOPERI
+*.DIOAREA
+*.EQUATION
+*.SCALE METER
+* .PARAM
+************************************************************************
+* Library Name: BAG_prim
+* Cell Name:    nmos4_standard_pcell_0
+* View Name:    schematic
+************************************************************************
+.SUBCKT nmos4_standard_pcell_0 B D G S
+*.PININFO B:B D:B G:B S:B
+mN0 D G S B nshort m=4 w=1.68 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
++ topography=normal area=0.063 perim=1.14
 .ENDS
-
+************************************************************************
+* Library Name: BAG_prim
+* Cell Name:    nmos4_standard_pcell_1
+* View Name:    schematic
+************************************************************************
+.SUBCKT nmos4_standard_pcell_1 B D G S
+*.PININFO B:B D:B G:B S:B
+mN0 D G S B nshort m=2 w=1.68 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
++ topography=normal area=0.063 perim=1.14
+.ENDS
+************************************************************************
+* Library Name: BAG_prim
+* Cell Name:    pmos4_standard_pcell_2
+* View Name:    schematic
+************************************************************************
+.SUBCKT pmos4_standard_pcell_2 B D G S
+*.PININFO B:B D:B G:B S:B
+mN0 D G S B pshort m=2 w=1.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
++ topography=normal area=0.063 perim=1.14
+.ENDS
+************************************************************************
+* Library Name: BAG_prim
+* Cell Name:    pmos4_standard_pcell_3
+* View Name:    schematic
+************************************************************************
+.SUBCKT pmos4_standard_pcell_3 B D G S
+*.PININFO B:B D:B G:B S:B
+mN0 D G S B pshort m=2 w=2.00 l=0.15 mult=1 sa=0.0 sb=0.0 sd=0.0 
++ topography=normal area=0.063 perim=1.14
+.ENDS
+************************************************************************
+* Library Name: AAA_Comp_SA_layers
+* Cell Name:    AAA_Comp_SA_sense
+* View Name:    schematic
+************************************************************************
+.SUBCKT AAA_Comp_SA_sense clk inn inp midn midp outn outp VDD VSS
+*.PININFO clk:I inn:I inp:I midn:O midp:O outn:O outp:O VDD:B VSS:B
+XXTAIL VSS tail clk VSS / nmos4_standard_pcell_0
+XXNFBP VSS outp outn midp / nmos4_standard_pcell_1
+XXNFBN VSS outn outp midn / nmos4_standard_pcell_1
+XXINP VSS midn inp tail / nmos4_standard_pcell_1
+XXINN VSS midp inn tail / nmos4_standard_pcell_1
+XXSWOP VDD outp clk VDD / pmos4_standard_pcell_2
+XXSWON VDD outn clk VDD / pmos4_standard_pcell_2
+XXSWMP VDD midp clk VDD / pmos4_standard_pcell_2
+XXSWMN VDD midn clk VDD / pmos4_standard_pcell_2
+XXPFBP VDD outp outn VDD / pmos4_standard_pcell_3
+XXPFBN VDD outn outp VDD / pmos4_standard_pcell_3
+.ENDS

--- a/sramgen/src/decoder.rs
+++ b/sramgen/src/decoder.rs
@@ -77,8 +77,8 @@ fn size_helper_tmp(x: &PlanTreeNode, _sizes: &[f64]) -> TreeNode {
         Gate::new(
             b,
             Size {
-                nmos_width: 2_000,
-                pmos_width: 2_800,
+                nmos_width: 1_600,
+                pmos_width: 2_400,
             },
         )
     });
@@ -87,7 +87,7 @@ fn size_helper_tmp(x: &PlanTreeNode, _sizes: &[f64]) -> TreeNode {
         gate: Gate::new(
             x.gate,
             Size {
-                nmos_width: 2_400,
+                nmos_width: 3_200,
                 pmos_width: 2_400,
             },
         ),

--- a/sramgen/src/decoder.rs
+++ b/sramgen/src/decoder.rs
@@ -77,8 +77,8 @@ fn size_helper_tmp(x: &PlanTreeNode, _sizes: &[f64]) -> TreeNode {
         Gate::new(
             b,
             Size {
-                nmos_width: 2_400,
-                pmos_width: 2_400,
+                nmos_width: 2_800,
+                pmos_width: 2_000,
             },
         )
     });

--- a/sramgen/src/decoder.rs
+++ b/sramgen/src/decoder.rs
@@ -77,8 +77,8 @@ fn size_helper_tmp(x: &PlanTreeNode, _sizes: &[f64]) -> TreeNode {
         Gate::new(
             b,
             Size {
-                nmos_width: 2_800,
-                pmos_width: 2_000,
+                nmos_width: 2_000,
+                pmos_width: 2_800,
             },
         )
     });

--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -155,7 +155,7 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
             instance_params: PrechargeParams {
                 name: "precharge".to_string(),
                 length: 150,
-                pull_up_width: 1_200,
+                pull_up_width: 1_000,
                 equalizer_width: 1_000,
             },
             name: "precharge_array".to_string(),

--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -819,17 +819,17 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
     let mut trace = router.trace(src, 2);
     trace.place_cursor(Dir::Horiz, true);
     trace.horiz_to(grid.vtrack(rmux_sel_0).stop());
-    power_grid.add_padded_blockage(2, trace.rect().expand(30));
+    power_grid.add_padded_blockage(2, trace.rect().expand(90));
     trace.down().vert_to(dst.top()).up().horiz_to(dst.right());
-    power_grid.add_padded_blockage(2, trace.rect().expand(30));
+    power_grid.add_padded_blockage(2, trace.rect().expand(90));
     let dst = read_mux.port("sel_1").largest_rect(m2).unwrap();
     let src = addr_0_traces[1];
     let mut trace = router.trace(src, 2);
     trace.place_cursor(Dir::Horiz, true);
     trace.horiz_to(grid.vtrack(rmux_sel_1).stop());
-    power_grid.add_padded_blockage(2, trace.rect().expand(30));
+    power_grid.add_padded_blockage(2, trace.rect().expand(90));
     trace.down().vert_to(dst.top()).up().horiz_to(dst.right());
-    power_grid.add_padded_blockage(2, trace.rect().expand(30));
+    power_grid.add_padded_blockage(2, trace.rect().expand(90));
 
     let sense_amp_bbox = sense_amp.bbox().into_rect();
     let din_dff_bbox = din_dffs.bbox().into_rect();

--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -733,6 +733,7 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
     trace.up().set_min_width().vert_to_rect(dst);
     power_grid.add_padded_blockage(3, trace.rect());
     trace.contact_down(dst).decrement_layer().contact_down(dst);
+    power_grid.add_padded_blockage(2, dst.expand(50));
 
     // Connect wldrv_nand b inputs to wordline enable (wl_en)
     for i in 0..rows {

--- a/sramgen/src/layout/bank.rs
+++ b/sramgen/src/layout/bank.rs
@@ -236,7 +236,8 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
     decoder1.align_beneath(core_bbox, 1_000);
     decoder1.align_to_the_left_of(sense_amp.bbox(), 3_000);
 
-    decoder2.align_beneath(decoder1.bbox(), 1_270);
+    let decoder1_bbox = decoder1.bbox();
+    decoder2.align_beneath(decoder1_bbox, 1_270);
     decoder2.align_to_the_left_of(sense_amp.bbox(), 3_000);
 
     let decoder2_bbox = decoder2.bbox();
@@ -246,7 +247,7 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
     wmask_control.align_beneath(decoder2_bbox, 1_270);
     wmask_control.align_to_the_right_of(control.bbox(), 1_270);
 
-    addr_dffs.align_top(decoder2_bbox);
+    addr_dffs.align_beneath(decoder1_bbox, 140);
 
     tmc.align_above(din_dffs.bbox(), 1_270);
     tmc.align_to_the_right_of(core_bbox, 1_270);
@@ -691,7 +692,8 @@ pub fn draw_sram_bank(rows: usize, cols: usize, lib: &mut PdkLib) -> Result<Ptr<
     let dst = control.port("we").largest_rect(m0).unwrap();
     let mut trace = router.trace(src, 2);
     trace.place_cursor_centered().horiz_to(dst.right() - 45);
-    power_grid.add_padded_blockage(2, trace.rect());
+    let blockage = trace.rect().expand(90);
+    power_grid.add_padded_blockage(2, blockage);
     trace
         .set_min_width()
         .down()

--- a/sramgen/src/layout/decoder.rs
+++ b/sramgen/src/layout/decoder.rs
@@ -545,16 +545,16 @@ fn draw_hier_decode_node(
     let nand_params = GateParams {
         name: format!("{}_nand_{}", ctx.prefix, id),
         size: Size {
-            nmos_width: 2_000,
-            pmos_width: 1_200,
+            nmos_width: 3_200,
+            pmos_width: 2_400,
         },
         length: 150,
     };
     let inv_params = GateParams {
         name: format!("{}_inv_{}", ctx.prefix, id),
         size: Size {
-            nmos_width: 2_000,
-            pmos_width: 1_200,
+            nmos_width: 1_600,
+            pmos_width: 2_400,
         },
         length: 150,
     };

--- a/sramgen/src/layout/gate.rs
+++ b/sramgen/src/layout/gate.rs
@@ -134,7 +134,7 @@ pub fn draw_nand2_dec(lib: &mut PdkLib, name: impl Into<String>) -> Result<Ptr<C
         GateParams {
             name: name.into(),
             size: Size {
-                nmos_width: 1_600,
+                nmos_width: 3_200,
                 pmos_width: 2_400,
             },
             length: 150,
@@ -432,8 +432,8 @@ pub fn draw_inv_dec(lib: &mut PdkLib, name: impl Into<String>) -> Result<Ptr<Cel
         GateParams {
             name: name.into(),
             size: Size {
-                nmos_width: 2_000,
-                pmos_width: 2_800,
+                nmos_width: 1_600,
+                pmos_width: 2_400,
             },
             length: 150,
         },

--- a/sramgen/src/layout/precharge.rs
+++ b/sramgen/src/layout/precharge.rs
@@ -123,8 +123,8 @@ pub fn draw_tap_cell(lib: &mut PdkLib) -> Result<Ptr<Cell>> {
         .name("pc_tap_cell")
         .bot_stack("ntap")
         .top_stack("viali")
-        .bot_rows(12)
-        .top_rows(11)
+        .bot_rows(10)
+        .top_rows(10)
         .build()?;
     let contact = draw_two_level_contact(lib, params)?;
     Ok(contact)

--- a/sramgen/src/precharge.rs
+++ b/sramgen/src/precharge.rs
@@ -144,7 +144,7 @@ pub fn precharge(params: PrechargeParams) -> Module {
             width: params.equalizer_width,
             length,
             drain: sig_conn(&bl),
-            source: sig_conn(&bl),
+            source: sig_conn(&br),
             gate: sig_conn(&en),
             body: sig_conn(&vdd),
             mos_type: MosType::Pmos,

--- a/sramgen/src/sram.rs
+++ b/sramgen/src/sram.rs
@@ -60,12 +60,12 @@ pub fn sram(params: SramParams) -> Vec<Module> {
             name: "wordline_driver".to_string(),
             length: 150,
             inv_size: Size {
-                pmos_width: 2_800,
-                nmos_width: 2_000,
+                pmos_width: 2_400,
+                nmos_width: 1_600,
             },
             nand_size: Size {
-                pmos_width: 1_600,
-                nmos_width: 2_400,
+                pmos_width: 2_400,
+                nmos_width: 3_200,
             },
         },
     });

--- a/sramgen/src/sram.rs
+++ b/sramgen/src/sram.rs
@@ -60,12 +60,12 @@ pub fn sram(params: SramParams) -> Vec<Module> {
             name: "wordline_driver".to_string(),
             length: 150,
             inv_size: Size {
-                pmos_width: 2_000,
-                nmos_width: 1_000,
+                pmos_width: 2_800,
+                nmos_width: 2_000,
             },
             nand_size: Size {
-                pmos_width: 2_000,
-                nmos_width: 1_000,
+                pmos_width: 1_600,
+                nmos_width: 2_400,
             },
         },
     });

--- a/sramgen/src/sram.rs
+++ b/sramgen/src/sram.rs
@@ -101,7 +101,7 @@ pub fn sram(params: SramParams) -> Vec<Module> {
         width: cols as i64,
         instance_params: ColumnMuxParams {
             length: 150,
-            width: 2_000,
+            width: 1_200,
         },
     });
 

--- a/sramgen/src/sram.rs
+++ b/sramgen/src/sram.rs
@@ -82,7 +82,7 @@ pub fn sram(params: SramParams) -> Vec<Module> {
         instance_params: PrechargeParams {
             name: "precharge".to_string(),
             length: 150,
-            pull_up_width: 2_000,
+            pull_up_width: 1_000,
             equalizer_width: 1_000,
         },
     });


### PR DESCRIPTION
- Fix sense amp and wordline driver property errors
- Fix decoder dimensions, update sense amp netlist
- Name sense amp subcircuit to `sramgen_sp_sense_amp`
- Fix: decoder inverter sizing
- Updated decoder and WL driver sizing
- Updated decoder and WL driver sizing in schematic
- Match precharge sizing in layout and schematic
- Fix precharge tap cell size
- Increase size of m2 blockages near read mux
- Adjust spacing of decoder and addr dffs
- Update netlist sizing of read muxes
- Correct colend netlist: npass on bl0
- Revert: npass in colend is on bl1
- bugfix: precharge equalizer now connects BL and BR
- Add power blockage near `wl_en`
