### PR TITLE
Fix LVS issue due to overlapping col data traces

### DIFF
--- a/sramgen/src/layout/bank/mod.rs
+++ b/sramgen/src/layout/bank/mod.rs
@@ -531,7 +531,9 @@ pub fn draw_sram_bank(lib: &mut PdkLib, params: SramBankParams) -> Result<Physic
                 .place_cursor(Dir::Vert, true)
                 .up()
                 .up()
-                .left_by(515)
+                .left_by(if i % 2 == 0 { 515 } else { 85 });
+            power_grid.add_padded_blockage(2, trace.rect().expand(90));
+            trace
                 .up()
                 .set_min_width()
                 .vert_to_rect(data_b_pin)


### PR DESCRIPTION
32x32m4 SRAM is now LVS clean.
