### PR TITLE
Fix write mask, dout bugs in Verilog models

### DIFF
--- a/sramgen/templates/sram_1rw.v
+++ b/sramgen/templates/sram_1rw.v
@@ -28,7 +28,6 @@ module {{module_name}}(
   reg  we_reg;
   reg [ADDR_WIDTH-1:0]  addr_reg;
   reg [DATA_WIDTH-1:0]  din_reg;
-  reg [DATA_WIDTH-1:0]  dout;
 
   reg [DATA_WIDTH-1:0] mem [0:RAM_DEPTH-1];
 
@@ -59,6 +58,9 @@ module {{module_name}}(
   begin : MEM_WRITE
     if (we_reg) begin
         mem[addr_reg] <= din_reg;
+
+        // Output is arbitrary when writing to SRAM
+        dout <= {DATA_WIDTH{1'bx}};
     end
   end
 

--- a/sramgen/templates/sram_1rw_wmask.v
+++ b/sramgen/templates/sram_1rw_wmask.v
@@ -9,7 +9,7 @@ module {{module_name}}(
     vdd,
     vss,
 `endif
-    clk,we,addr,din,dout
+    clk,we,wmask,addr,din,dout
   );
 
   parameter DATA_WIDTH = {{data_width}} ;
@@ -32,7 +32,6 @@ module {{module_name}}(
   reg [WMASK_WIDTH-1:0] wmask_reg;
   reg [ADDR_WIDTH-1:0]  addr_reg;
   reg [DATA_WIDTH-1:0]  din_reg;
-  reg [DATA_WIDTH-1:0]  dout;
 
   reg [DATA_WIDTH-1:0] mem [0:RAM_DEPTH-1];
 
@@ -70,7 +69,9 @@ module {{module_name}}(
           mem[addr_reg][{{upper}}:{{lower}}] <= din_reg[{{upper}}:{{lower}}];
         end
       {% endfor %}
-      mem[addr_reg] <= din_reg;
+
+      // Output is arbitrary when writing to SRAM
+      dout <= {DATA_WIDTH{1'bx}};
     end
   end
 


### PR DESCRIPTION
Fix 2 bugs:
1. `dout` was doubly defined in the `1rw` and `1rw_wmask` Verilog
   templates. The second declaration was removed.
2. `wmask` was not declared as a port in the `1rw_wmask` template.
