### PR TITLE
Add inverter chain grid layout generator

### DIFF
--- a/sramgen/src/layout/inv_chain.rs
+++ b/sramgen/src/layout/inv_chain.rs
@@ -1,0 +1,232 @@
+use crate::layout::bank::GateList;
+use crate::layout::common::MergeArgs;
+use crate::tech::{sc_inv_gds, sc_tap_gds};
+use crate::{bus_bit, Result};
+
+use layout21::raw::{Cell, Instance, Point};
+use layout21::utils::Ptr;
+use pdkprims::PdkLib;
+
+use super::common::sc_outline;
+use super::route::Router;
+
+pub struct InvChainParams<'a> {
+    pub prefix: &'a str,
+    pub num: usize,
+}
+
+pub fn draw_inv_chain(lib: &mut PdkLib, params: InvChainParams) -> Result<Ptr<Cell>> {
+    let mut cell = Cell::empty(params.prefix);
+
+    let inv = sc_inv_gds(lib)?;
+    let tap = sc_tap_gds(lib)?;
+
+    let tap0 = Instance::new("tap0", tap.clone());
+    let tmp = Instance::new("", inv.clone());
+    let inv_outline = sc_outline(&lib.pdk, &tmp);
+    let tap_outline = sc_outline(&lib.pdk, &tap0);
+
+    let mut router = Router::new(format!("{}_route", params.prefix), lib.pdk.clone());
+    let cfg = router.cfg();
+    let m0 = cfg.layerkey(0);
+    let m1 = cfg.layerkey(1);
+
+    let mut x = tap_outline.p1.x;
+    let mut prev: Option<Instance> = None;
+    for i in 0..params.num {
+        let mut inv = Instance::new(format!("inv_{}", i), inv.clone());
+        inv.loc.x = x;
+        x += inv_outline.width();
+        if let Some(prev) = prev {
+            let dst = prev.port("y").largest_rect(m0).unwrap();
+            let src = inv.port("a").largest_rect(m0).unwrap();
+
+            let mut trace = router.trace(src, 0);
+            trace
+                .place_cursor(layout21::raw::Dir::Horiz, false)
+                .horiz_to(dst.left());
+        }
+        cell.layout_mut().add_inst(inv.clone());
+
+        if i == 0 {
+            let rect = inv.port("a").largest_rect(m0).unwrap();
+            cell.add_pin("din", m0, rect);
+        } else if i == params.num - 1 {
+            let rect = inv.port("y").largest_rect(m0).unwrap();
+            cell.add_pin("dout", m0, rect);
+        }
+
+        prev = Some(inv);
+    }
+
+    let mut tap1 = Instance::new("tap1", tap);
+    tap1.loc.x = x;
+
+    cell.layout_mut().add_inst(tap0);
+    cell.layout_mut().add_inst(tap1);
+
+    let rect = MergeArgs::builder()
+        .layer(m1)
+        .insts(GateList::Cells(&cell.layout().insts))
+        .port_name("vgnd")
+        .build()?
+        .rect();
+    cell.add_pin("vss", m1, rect);
+
+    let rect = MergeArgs::builder()
+        .layer(m1)
+        .insts(GateList::Cells(&cell.layout().insts))
+        .port_name("vpwr")
+        .build()?
+        .rect();
+    cell.add_pin("vdd", m1, rect);
+
+    cell.layout_mut().add_inst(router.finish());
+
+    let ptr = Ptr::new(cell);
+    lib.lib.cells.push(ptr.clone());
+
+    Ok(ptr)
+}
+
+pub struct InvChainGridParams<'a> {
+    pub prefix: &'a str,
+    pub rows: usize,
+    pub cols: usize,
+}
+
+pub fn draw_inv_chain_grid(lib: &mut PdkLib, params: InvChainGridParams) -> Result<Ptr<Cell>> {
+    let InvChainGridParams { prefix, rows, cols } = params;
+    let mut cell = Cell::empty(prefix);
+
+    let inv = sc_inv_gds(lib)?;
+    let tap = sc_tap_gds(lib)?;
+
+    let tap0 = Instance::new("", tap.clone());
+    let inv0 = Instance::new("", inv.clone());
+    let tap_outline = sc_outline(&lib.pdk, &tap0);
+    let inv_outline = sc_outline(&lib.pdk, &inv0);
+
+    assert_eq!(tap_outline.height(), inv_outline.height());
+
+    let mut router = Router::new(format!("{}_route", prefix), lib.pdk.clone());
+    let cfg = router.cfg();
+    let m0 = cfg.layerkey(0);
+    let m1 = cfg.layerkey(1);
+
+    let start_x = 0;
+    let mut x;
+    let mut y = 0;
+    let mut prev: Option<Instance> = None;
+    let mut row_cells = Vec::with_capacity(cols + 2);
+    for j in 0..rows {
+        x = start_x;
+        row_cells.clear();
+
+        let mut xtap = Instance::new(format!("tap_left_{j}"), tap.clone());
+        xtap.loc = Point::new(x, y);
+        x += tap_outline.width();
+        if j % 2 != 0 {
+            xtap.reflect_vert_anchored();
+        }
+        row_cells.push(xtap.clone());
+        cell.layout_mut().add_inst(xtap);
+
+        for i in 0..cols {
+            let mut xinv = Instance::new(format!("inv_{j}_{i}"), inv.clone());
+            xinv.loc = Point::new(x, y);
+            x += inv_outline.width();
+            if j % 2 != 0 {
+                xinv.reflect_vert_anchored();
+            }
+            if i == 0 && j == 0 {
+                let rect = xinv.port("a").largest_rect(m0).unwrap();
+                cell.add_pin("din", m0, rect);
+            } else if i == cols - 1 && j == rows - 1 {
+                let rect = xinv.port("y").largest_rect(m0).unwrap();
+                cell.add_pin("dout", m0, rect);
+            }
+            // Routing - connect the previous inverter to the next one in the chain
+            if let Some(prev) = prev {
+                let dst = prev.port("y").largest_rect(m0).unwrap();
+                let src = xinv.port("a").largest_rect(m0).unwrap();
+
+                if i != 0 {
+                    // Within row routing
+                    let mut trace = router.trace(src, 0);
+                    trace
+                        .place_cursor(layout21::raw::Dir::Horiz, false)
+                        .horiz_to(dst.left());
+                } else {
+                    // Route from previous row
+                    let mut trace = router.trace(dst, 0);
+                    trace
+                        .place_cursor_centered()
+                        .up()
+                        .left_by(600)
+                        .up()
+                        .vert_to(src.top() + 500)
+                        .down()
+                        .horiz_to_rect(src)
+                        .vert_to_rect(src)
+                        .contact_down(src);
+                }
+            }
+            cell.layout_mut().add_inst(xinv.clone());
+            row_cells.push(xinv.clone());
+            prev = Some(xinv);
+        }
+
+        let mut xtap = Instance::new(format!("tap_right_{j}"), tap.clone());
+        xtap.loc = Point::new(x, y);
+        if j % 2 != 0 {
+            xtap.reflect_vert_anchored();
+        }
+        row_cells.push(xtap.clone());
+        cell.layout_mut().add_inst(xtap);
+
+        if j % 2 != 0 {
+            let rect = MergeArgs::builder()
+                .layer(m1)
+                .insts(GateList::Cells(&row_cells))
+                .port_name("vgnd")
+                .build()?
+                .rect();
+            cell.add_pin(bus_bit("vss", j / 2), m1, rect);
+        } else {
+            let rect = MergeArgs::builder()
+                .layer(m1)
+                .insts(GateList::Cells(&row_cells))
+                .port_name("vpwr")
+                .build()?
+                .rect();
+            cell.add_pin(bus_bit("vdd", j / 2), m1, rect);
+        }
+
+        // Special case: need to handle the final power rail
+        if j == rows - 1 {
+            let (iport, xport) = if j % 2 != 0 {
+                ("vpwr", "vdd")
+            } else {
+                ("vgnd", "vss")
+            };
+
+            let rect = MergeArgs::builder()
+                .layer(m1)
+                .insts(GateList::Cells(&row_cells))
+                .port_name(iport)
+                .build()?
+                .rect();
+            cell.add_pin(bus_bit(xport, j / 2), m1, rect);
+        }
+
+        y -= tap_outline.height();
+    }
+
+    cell.layout_mut().add_inst(router.finish());
+
+    let ptr = Ptr::new(cell);
+    lib.lib.cells.push(ptr.clone());
+
+    Ok(ptr)
+}

--- a/sramgen/src/layout/mod.rs
+++ b/sramgen/src/layout/mod.rs
@@ -16,6 +16,7 @@ pub mod dout_buffer;
 pub mod gate;
 pub mod grid;
 pub mod guard_ring;
+pub mod inv_chain;
 pub mod latch;
 pub mod mux;
 pub mod power;

--- a/sramgen/src/tests/control.rs
+++ b/sramgen/src/tests/control.rs
@@ -15,19 +15,3 @@ fn test_sky130_control_logic_simple() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_sky130_inv_chain_12() -> Result<()> {
-    let name = "sramgen_inv_chain_12";
-    let mut lib = sky130::pdk_lib(name)?;
-    draw_inv_chain(
-        &mut lib,
-        InvChainParams {
-            prefix: name,
-            num: 12,
-        },
-    )?;
-
-    lib.save_gds(test_gds_path(name))?;
-
-    Ok(())
-}

--- a/sramgen/src/tests/control.rs
+++ b/sramgen/src/tests/control.rs
@@ -14,4 +14,3 @@ fn test_sky130_control_logic_simple() -> Result<()> {
 
     Ok(())
 }
-

--- a/sramgen/src/tests/inv_chain.rs
+++ b/sramgen/src/tests/inv_chain.rs
@@ -1,0 +1,40 @@
+use crate::layout::inv_chain::*;
+use crate::tests::test_gds_path;
+use crate::Result;
+use pdkprims::tech::sky130;
+
+#[test]
+fn test_inv_chain_grid() -> Result<()> {
+    let name = "sramgen_inv_chain_grid_5x9";
+
+    let mut lib = sky130::pdk_lib(name)?;
+    draw_inv_chain_grid(
+        &mut lib,
+        InvChainGridParams {
+            prefix: name,
+            rows: 5,
+            cols: 9,
+        },
+    )?;
+
+    lib.save_gds(test_gds_path(name))?;
+
+    Ok(())
+}
+
+#[test]
+fn test_sky130_inv_chain_12() -> Result<()> {
+    let name = "sramgen_inv_chain_12";
+    let mut lib = sky130::pdk_lib(name)?;
+    draw_inv_chain(
+        &mut lib,
+        InvChainParams {
+            prefix: name,
+            num: 12,
+        },
+    )?;
+
+    lib.save_gds(test_gds_path(name))?;
+
+    Ok(())
+}

--- a/sramgen/src/tests/mod.rs
+++ b/sramgen/src/tests/mod.rs
@@ -25,6 +25,7 @@ mod dff;
 mod dout_buffer;
 mod gate;
 mod guard_ring;
+mod inv_chain;
 mod latch;
 mod mux;
 mod precharge;

--- a/sramgen/src/tests/sram.rs
+++ b/sramgen/src/tests/sram.rs
@@ -11,6 +11,7 @@ pub(crate) mod calibre {
     use crate::{Result, BUILD_PATH};
     use calibre::drc::{run_drc, DrcParams};
     use calibre::lvs::{run_lvs, LvsParams, LvsStatus};
+    #[cfg(feature = "pex")]
     use calibre::pex::{run_pex, PexParams};
     use calibre::RuleCheck;
     use std::path::PathBuf;
@@ -18,6 +19,8 @@ pub(crate) mod calibre {
     const SKY130_DRC_RULES_PATH: &str = "/tools/B/rahulkumar/sky130/priv/drc/sram_drc_rules";
     const SKY130_LVS_RULES_PATH: &str =
         "/tools/commercial/skywater/swtech130/skywater-src-nda/s8/V2.0.1/LVS/Calibre/lvs_s8_opts";
+
+    #[cfg(feature = "pex")]
     const SKY130_PEX_RULES_PATH: &str =
         "/tools/commercial/skywater/swtech130/skywater-src-nda/s8/V2.0.1/PEX/xRC/xrcControlFile_s8";
 


### PR DESCRIPTION
Given a number of rows and columns, generates a chain of
`rows * columns` inverters connected in series.

The inverters are laid out in a grid with `rows` rows
and `columns` columns.
