### PR TITLE
Add positive edge detector

### DIFF
--- a/sramgen/src/schematic/edge_detector.rs
+++ b/sramgen/src/schematic/edge_detector.rs
@@ -1,0 +1,89 @@
+use std::collections::HashMap;
+
+use vlsir::circuit::{Instance, Module};
+
+use crate::layout::inv_chain::InvChainGridParams;
+use crate::schematic::conns::{conn_map, port_inout, port_input, port_output, sig_conn, signal};
+
+use super::gate::{and2, AndParams};
+use super::inv_chain::inv_chain_grid;
+use super::local_reference;
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct EdgeDetectorParams<'a> {
+    pub prefix: &'a str,
+    pub num_inverters: usize,
+    pub and_params: &'a AndParams,
+}
+
+pub fn edge_detector(params: EdgeDetectorParams) -> Vec<Module> {
+    assert_eq!(params.num_inverters % 2, 1);
+
+    let EdgeDetectorParams {
+        prefix,
+        num_inverters,
+        and_params,
+    } = params;
+    let vdd = signal("vdd");
+    let vss = signal("vss");
+    let din = signal("din");
+    let dout = signal("dout");
+    let delayed = signal("delayed");
+
+    let ports = vec![
+        port_input(&din),
+        port_output(&dout),
+        port_inout(&vdd),
+        port_inout(&vss),
+    ];
+
+    let inv_chain_name = format!("{}_invs", prefix);
+    let chain = inv_chain_grid(InvChainGridParams {
+        prefix: &inv_chain_name,
+        rows: 1,
+        cols: num_inverters,
+    });
+    let mut and2 = and2(and_params.clone());
+
+    let mut m = Module {
+        name: prefix.to_string(),
+        ports,
+        signals: vec![],
+        instances: vec![],
+        parameters: vec![],
+    };
+
+    let mut connections = HashMap::new();
+    connections.insert("din", sig_conn(&din));
+    connections.insert("dout", sig_conn(&delayed));
+    connections.insert("vdd", sig_conn(&vdd));
+    connections.insert("vss", sig_conn(&vss));
+
+    m.instances.push(Instance {
+        name: "delay_chain".to_string(),
+        module: local_reference(inv_chain_name),
+        parameters: HashMap::new(),
+        connections: conn_map(connections),
+    });
+
+    let mut connections = HashMap::new();
+    connections.insert("a", sig_conn(&din));
+    connections.insert("b", sig_conn(&delayed));
+    connections.insert("y", sig_conn(&dout));
+    connections.insert("vdd", sig_conn(&vdd));
+    connections.insert("vss", sig_conn(&vss));
+
+    m.instances.push(Instance {
+        name: "and".to_string(),
+        module: local_reference(&and_params.name),
+        parameters: HashMap::new(),
+        connections: conn_map(connections),
+    });
+
+    let mut modules = Vec::new();
+    modules.push(chain);
+    modules.append(&mut and2);
+    modules.push(m);
+
+    modules
+}

--- a/sramgen/src/schematic/mod.rs
+++ b/sramgen/src/schematic/mod.rs
@@ -16,6 +16,7 @@ pub mod col_inv;
 pub mod decoder;
 pub mod dff;
 pub mod dout_buffer;
+pub mod edge_detector;
 pub mod gate;
 pub mod inv_chain;
 pub mod mos;

--- a/sramgen/src/tests/edge_detector.rs
+++ b/sramgen/src/tests/edge_detector.rs
@@ -1,0 +1,56 @@
+use crate::paths::out_bin;
+use crate::schematic::edge_detector::{edge_detector, EdgeDetectorParams};
+use crate::schematic::gate::{AndParams, GateParams, Size};
+use crate::schematic::{generate_netlist, save_bin};
+use crate::tech::all_external_modules;
+use crate::tests::test_work_dir;
+use crate::Result;
+use vlsir::circuit::Package;
+
+#[test]
+fn test_edge_detector() -> Result<()> {
+    let name = "sramgen_edge_detector";
+
+    let and_params = AndParams {
+        name: "and2".to_string(),
+        nand: GateParams {
+            name: "and2_nand".to_string(),
+            length: 150,
+            size: Size {
+                pmos_width: 2_400,
+                nmos_width: 1_800,
+            },
+        },
+        inv: GateParams {
+            name: "and2_inv".to_string(),
+            length: 150,
+            size: Size {
+                pmos_width: 2_400,
+                nmos_width: 1_800,
+            },
+        },
+    };
+
+    let params = EdgeDetectorParams {
+        prefix: name,
+        num_inverters: 5,
+        and_params: &and_params,
+    };
+    let modules = edge_detector(params);
+    let ext_modules = all_external_modules();
+    let pkg = Package {
+        domain: name.to_string(),
+        desc: "Sramgen generated cells".to_string(),
+        modules,
+        ext_modules,
+    };
+
+    let work_dir = test_work_dir(name);
+
+    let bin_path = out_bin(&work_dir, name);
+    save_bin(&bin_path, name, pkg)?;
+
+    generate_netlist(&bin_path, &work_dir)?;
+
+    Ok(())
+}

--- a/sramgen/src/tests/mod.rs
+++ b/sramgen/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod control;
 mod decoder;
 mod dff;
 mod dout_buffer;
+mod edge_detector;
 mod gate;
 mod guard_ring;
 mod inv_chain;


### PR DESCRIPTION
Emits a short pulse upon a positive going edge.
The pulse width can be controlled by selecting the number
of inverters. A longer inverter chain results in a longer
pulse width.
