### PR TITLE
control logic layout

### DIFF
--- a/src/blocks/control/layout.rs
+++ b/src/blocks/control/layout.rs
@@ -1488,7 +1488,7 @@ impl EdgeDetector {
         let mut dout_via = via.with_orientation(Named::R90);
         dout_via.align_centers_gridded(dout.bbox(), grid);
         dout_via.align_centers_vertically_gridded(b_via.bbox(), grid);
-        dout_via.translate(Point::new(0, -380));
+        dout_via.translate(Point::new(0, -340));
         row.add(dout_via.clone());
 
         row.add_group(

--- a/src/blocks/control/layout.rs
+++ b/src/blocks/control/layout.rs
@@ -363,7 +363,7 @@ impl ControlLogicReplicaV2 {
         via.align_centers_gridded(pin.bbox(), grid);
         let rbl_in = router.expand_to_grid(
             via.layer_bbox(m1).into_rect(),
-            ExpandToGridStrategy::Corner(Corner::UpperRight),
+            ExpandToGridStrategy::Corner(Corner::UpperLeft),
         );
         ctx.draw(via)?;
         ctx.draw_rect(m1, rbl_in);

--- a/src/blocks/control/layout.rs
+++ b/src/blocks/control/layout.rs
@@ -1253,7 +1253,7 @@ impl SrLatch {
 
         via.align_centers_gridded(y0.largest_rect(m0)?, grid);
         via.align_bottom(y0.largest_rect(m0)?);
-        via.translate(Point::new(0, -320));
+        via.translate(Point::new(0, -360));
         let y0_via = via.clone();
 
         via.align_left(a1.largest_rect(m0)?);

--- a/src/blocks/control/layout.rs
+++ b/src/blocks/control/layout.rs
@@ -255,7 +255,8 @@ impl ControlLogicReplicaV2 {
 
         for layer in [m1, m2] {
             for shape in group.shapes_on(layer) {
-                router.block(layer, shape.brect());
+                let rect = shape.brect().expand(40);
+                router.block(layer, rect);
             }
         }
 
@@ -295,7 +296,7 @@ impl ControlLogicReplicaV2 {
         for i in 0..num_bot_pins {
             let vtrack = vtracks.index(vtrack_start + 2 * (i as i64) + left_offset);
             bot_pins.push(Rect::from_spans(vtrack, htrack));
-            ctx.draw_rect(m1, bot_pins[i]);
+            ctx.draw_rect(m2, bot_pins[i]);
         }
 
         router.block(
@@ -950,7 +951,7 @@ impl ControlLogicReplicaV2 {
         router.route_with_net(ctx, m1, wlend_out, m1, wlend_in, "wlend")?;
         router.route_with_net(ctx, m1, wlen_out, m2, wlen_pin, "wlen")?;
         router.route_with_net(ctx, m1, saen_out, m2, saen_pin, "saen")?;
-        router.route_with_net(ctx, m1, wrdrven_out, m2, wrdrven_pin, "wrdrven")?;
+        router.route_with_net(ctx, m2, wrdrven_pin, m1, wrdrven_out, "wrdrven")?;
         router.route_with_net(ctx, m2, rbl_pin, m1, rbl_in, "rbl")?;
         router.route_with_net(
             ctx,

--- a/src/blocks/control/layout.rs
+++ b/src/blocks/control/layout.rs
@@ -477,7 +477,7 @@ impl ControlLogicReplicaV2 {
         via.align_centers_gridded(pin.bbox(), grid);
         let clkp_b_in_1 = router.expand_to_grid(
             via.layer_bbox(m1).into_rect(),
-            ExpandToGridStrategy::Corner(Corner::UpperRight),
+            ExpandToGridStrategy::Side(Side::Right),
         );
         ctx.draw(via)?;
         ctx.draw_rect(m1, clkp_b_in_1);
@@ -934,11 +934,11 @@ impl ControlLogicReplicaV2 {
         router.route_with_net(ctx, m1, clkp_out, m1, clkp_in, "clkp")?;
         router.route_with_net(ctx, m1, clkp_grstb_out, m1, clkp_grstb_in, "clkp_grst_b")?;
         router.route_with_net(ctx, m1, wlendb_out, m1, wlendb_in, "wlend_b")?;
+        router.route_with_net(ctx, m1, wlend_out, m1, wlend_in, "wlend")?;
         router.route_with_net(ctx, m1, wlen_out, m1, wlen_pin, "wlen")?;
         router.route_with_net(ctx, m1, saen_out, m1, saen_pin, "saen")?;
         router.route_with_net(ctx, m1, wrdrven_out, m1, wrdrven_pin, "wrdrven")?;
         router.route_with_net(ctx, m1, rwl_out, m1, rwl_pin, "rwl")?;
-        router.route_with_net(ctx, m1, wlend_out, m1, wlend_in, "wlend_b")?;
         router.route_with_net(ctx, m1, rbl_pin, m1, rbl_in, "rbl")?;
         router.route_with_net(
             ctx,
@@ -1262,6 +1262,7 @@ impl SrLatch {
 
         via.align_centers_gridded(y1.largest_rect(m0)?, grid);
         via.align_top(y1.largest_rect(m0)?);
+        via.translate(Point::new(0, 100));
         let y1_via = via.clone();
 
         via.align_centers_gridded(aq0.largest_rect(m0)?, grid);

--- a/src/blocks/control/layout.rs
+++ b/src/blocks/control/layout.rs
@@ -1480,7 +1480,7 @@ impl EdgeDetector {
 
         let b = row.port_map().port(PortId::new("b", 1))?.largest_rect(m0)?;
         let mut b_via = via.with_orientation(Named::R90);
-        b_via.align_centers_gridded(b.bbox(), grid);
+        b_via.align_left(b.bbox());
         b_via.align_bottom(b.bbox());
         row.add(b_via.clone());
 
@@ -1500,10 +1500,17 @@ impl EdgeDetector {
                 .unwrap()
                 .draw()?,
         );
+        let src = dout_via.layer_bbox(m1).into_rect().edge(Side::Right);
+        let len = src.span().length();
         row.add_group(
             ElbowJog::builder()
-                .src(dout_via.layer_bbox(m1).into_rect().edge(Side::Right))
-                .dst(b_via.brect().center())
+                .src(src)
+                .dst(
+                    b_via
+                        .brect()
+                        .center()
+                        .translated(Point::new(-(290 - len) / 2, 0)),
+                )
                 .layer(m1)
                 .build()
                 .unwrap()

--- a/src/blocks/control/layout.rs
+++ b/src/blocks/control/layout.rs
@@ -1269,8 +1269,8 @@ impl SrLatch {
         via.align_bottom(aq0.largest_rect(m0)?);
         let aq0_via = via.clone();
 
-        via.align_centers_gridded(aq0b.largest_rect(m0)?, grid);
         via.align_top(aq0b.largest_rect(m0)?);
+        via.align_left(aq0b.largest_rect(m0)?);
         via.translate(Point::new(0, -40));
         let aq0b_via = via.clone();
 

--- a/src/blocks/control/layout.rs
+++ b/src/blocks/control/layout.rs
@@ -931,6 +931,7 @@ impl ControlLogicReplicaV2 {
         router.route_with_net(ctx, m1, we_pin, m1, we_in_1, "we")?;
         router.route_with_net(ctx, m1, we_pin, m1, we_in_inv, "we")?;
         router.route_with_net(ctx, m1, rbl_b_out, m1, rbl_b_in, "rbl_b")?;
+        router.route_with_net(ctx, m1, rwl_out, m1, rwl_pin, "rwl")?;
         router.route_with_net(ctx, m1, wlen_grstb_out, m1, wlen_grstb_in, "wlen_grst_b")?;
         router.route_with_net(ctx, m1, clkp_out, m1, clkp_in, "clkp")?;
         router.route_with_net(ctx, m1, clkp_grstb_out, m1, clkp_grstb_in, "clkp_grst_b")?;
@@ -939,7 +940,6 @@ impl ControlLogicReplicaV2 {
         router.route_with_net(ctx, m1, wlen_out, m1, wlen_pin, "wlen")?;
         router.route_with_net(ctx, m1, saen_out, m1, saen_pin, "saen")?;
         router.route_with_net(ctx, m1, wrdrven_out, m1, wrdrven_pin, "wrdrven")?;
-        router.route_with_net(ctx, m1, rwl_out, m1, rwl_pin, "rwl")?;
         router.route_with_net(ctx, m1, rbl_pin, m1, rbl_in, "rbl")?;
         router.route_with_net(
             ctx,
@@ -1343,6 +1343,8 @@ impl InvChain {
         let lib = stdcells.try_lib_named("sky130_fd_sc_hs")?;
         let inv = lib.try_cell_named("sky130_fd_sc_hs__inv_2")?;
         let inv = ctx.instantiate::<StdCell>(&inv.id())?;
+        let inv_end = lib.try_cell_named("sky130_fd_sc_hs__inv_4")?;
+        let inv_end = ctx.instantiate::<StdCell>(&inv_end.id())?;
         let tap = lib.try_cell_named("sky130_fd_sc_hs__tap_2")?;
         let tap = ctx.instantiate::<StdCell>(&tap.id())?;
 
@@ -1355,10 +1357,12 @@ impl InvChain {
         let num_groups = self.n.div_ceil(group_size);
         for i in 0..num_groups {
             if i == num_groups - 1 {
+                let rem = self.n - (num_groups - 1) * group_size;
                 row.push_num(
                     LayerBbox::new(inv.clone(), outline),
-                    self.n - (num_groups - 1) * group_size,
+                    rem.checked_sub(1).unwrap(),
                 );
+                row.push(LayerBbox::new(inv_end.clone(), outline));
             } else {
                 row.push_num(LayerBbox::new(inv.clone(), outline), group_size);
                 row.push(LayerBbox::new(tap.clone(), outline));

--- a/src/blocks/control/layout.rs
+++ b/src/blocks/control/layout.rs
@@ -434,9 +434,10 @@ impl ControlLogicReplicaV2 {
         let wlend_in = group.port_map().port("and_wlen_b")?.largest_rect(m0)?;
         let mut via = via01.clone();
         via.align_centers_gridded(wlend_in.bbox(), grid);
+        via.align_right(wlend_in.bbox());
         let wlend_in = router.expand_to_grid(
             via.layer_bbox(m1).into_rect(),
-            ExpandToGridStrategy::Corner(Corner::LowerLeft),
+            ExpandToGridStrategy::Corner(Corner::UpperRight),
         );
         ctx.draw(via)?;
         ctx.draw_rect(m1, wlend_in);

--- a/src/blocks/control/layout.rs
+++ b/src/blocks/control/layout.rs
@@ -712,7 +712,7 @@ impl ControlLogicReplicaV2 {
         via.align_centers_gridded(we_in_inv.bbox(), grid);
         let we_in_inv = router.expand_to_grid(
             via.layer_bbox(m1).into_rect(),
-            ExpandToGridStrategy::Corner(Corner::UpperRight),
+            ExpandToGridStrategy::Corner(Corner::LowerLeft),
         );
         ctx.draw(via)?;
         ctx.draw_rect(m1, we_in_inv);

--- a/src/blocks/control/schematic.rs
+++ b/src/blocks/control/schematic.rs
@@ -9,12 +9,10 @@ use super::{ControlLogicReplicaV2, EdgeDetector, InvChain, SrLatch};
 impl ControlLogicReplicaV2 {
     pub(crate) fn schematic(&self, ctx: &mut SchematicCtx) -> substrate::error::Result<()> {
         // PORTS
-        let [clk, ce, we, reset_b, decrepend, rbl] = ctx.ports(
-            ["clk", "ce", "we", "reset_b", "decrepend", "rbl"],
-            Direction::Input,
-        );
-        let [saen, pc_b, rwl, wlen, wrdrven, decrepstart] = ctx.ports(
-            ["saen", "pc_b", "rwl", "wlen", "wrdrven", "decrepstart"],
+        let [clk, ce, we, reset_b, rbl] =
+            ctx.ports(["clk", "ce", "we", "reset_b", "rbl"], Direction::Input);
+        let [saen, pc_b, rwl, wlen, wrdrven] = ctx.ports(
+            ["saen", "pc_b", "rwl", "wlen", "wrdrven"],
             Direction::Output,
         );
         let [vdd, vss] = ctx.ports(["vdd", "vss"], Direction::InOut);
@@ -30,6 +28,7 @@ impl ControlLogicReplicaV2 {
             "clkpdd",
             "clkp_grst_b",
         ]);
+        let [decrepstart, decrepend] = ctx.signals(["decrepstart", "decrepend"]);
         let [wlen_grst_b, wlen_rst_decoderd, wlen_b, wlen_q, wlend_b, wlend] = ctx.signals([
             "wlen_grst_b",
             "wlen_rst_decoderd",
@@ -153,6 +152,15 @@ impl ControlLogicReplicaV2 {
                 ("VNB", vss),
             ])
             .named("mux_wlen_rst")
+            .add_to(ctx);
+        ctx.instantiate::<InvChain>(&16)?
+            .with_connections([
+                ("din", decrepstart),
+                ("dout", decrepend),
+                ("vdd", vdd),
+                ("vss", vss),
+            ])
+            .named("decoder_replica")
             .add_to(ctx);
         ctx.instantiate::<InvChain>(&6)?
             .with_connections([

--- a/src/blocks/control/schematic.rs
+++ b/src/blocks/control/schematic.rs
@@ -9,15 +9,15 @@ use super::{ControlLogicReplicaV2, EdgeDetector, InvChain, SrLatch};
 impl ControlLogicReplicaV2 {
     pub(crate) fn schematic(&self, ctx: &mut SchematicCtx) -> substrate::error::Result<()> {
         // PORTS
-        let [clk, ce, we, reset_b, decrepend] = ctx.ports(
-            ["clk", "ce", "we", "reset_b", "decrepend"],
+        let [clk, ce, we, reset_b, decrepend, rbl] = ctx.ports(
+            ["clk", "ce", "we", "reset_b", "decrepend", "rbl"],
             Direction::Input,
         );
         let [saen, pc_b, rwl, wlen, wrdrven, decrepstart] = ctx.ports(
             ["saen", "pc_b", "rwl", "wlen", "wrdrven", "decrepstart"],
             Direction::Output,
         );
-        let [rbl, vdd, vss] = ctx.ports(["rbl", "vdd", "vss"], Direction::InOut);
+        let [vdd, vss] = ctx.ports(["vdd", "vss"], Direction::InOut);
 
         // SIGNALS
         let [clk_buf, clkp0, clkp, clkp_b, clkpd, clkpd_b, clkpdd, clkp_grst_b] = ctx.signals([

--- a/src/blocks/control/schematic.rs
+++ b/src/blocks/control/schematic.rs
@@ -53,7 +53,6 @@ impl ControlLogicReplicaV2 {
         let nand2 = lib.try_cell_named("sky130_fd_sc_hs__nand2_4")?;
         let nor2 = lib.try_cell_named("sky130_fd_sc_hs__nor2_4")?;
         let mux2 = lib.try_cell_named("sky130_fd_sc_hs__mux2_4")?;
-        let buf_small = lib.try_cell_named("sky130_fd_sc_hs__buf_8")?;
         let buf = lib.try_cell_named("sky130_fd_sc_hs__buf_16")?;
         let biginv = lib.try_cell_named("sky130_fd_sc_hs__inv_16")?;
 
@@ -244,7 +243,7 @@ impl ControlLogicReplicaV2 {
                 ("VGND", vss),
                 ("VNB", vss),
             ])
-            .named("and_sense_en")
+            .named("nand_sense_en")
             .add_to(ctx);
         ctx.instantiate::<StdCell>(&nand2.id())?
             .with_connections([

--- a/src/blocks/control/schematic.rs
+++ b/src/blocks/control/schematic.rs
@@ -377,8 +377,8 @@ impl SrLatch {
         let mut nand_reset = nand_set.clone();
 
         nand_set.connect_all([
-            ("A", sb),
-            ("B", q0b),
+            ("A", q0b),
+            ("B", sb),
             ("Y", q0),
             ("VPWR", vdd),
             ("VPB", vdd),
@@ -389,8 +389,8 @@ impl SrLatch {
         ctx.add_instance(nand_set);
 
         nand_reset.connect_all([
-            ("A", rb),
-            ("B", q0),
+            ("A", q0),
+            ("B", rb),
             ("Y", q0b),
             ("VPWR", vdd),
             ("VPB", vdd),

--- a/src/blocks/sram/schematic.rs
+++ b/src/blocks/sram/schematic.rs
@@ -98,7 +98,6 @@ impl SramInner {
                 "sense_en_b",
                 "sense_en",
             ]);
-        let [decrepstart, decrepend] = ctx.signals(["decrepstart", "decrepend"]);
 
         let wl_cap = (self.params.cols() + 4) as f64 * WORDLINE_CAP_PER_CELL;
         let tree = DecoderTree::new(self.params.row_bits(), wl_cap);
@@ -170,23 +169,12 @@ impl SramInner {
                 ("pc_b", pc_b0),
                 ("wlen", wl_en0),
                 ("wrdrven", write_driver_en0),
-                ("decrepstart", decrepstart),
-                ("decrepend", decrepend),
                 ("saen", sense_en0),
                 ("vdd", vdd),
                 ("vss", vss),
             ])
             .named("control_logic");
         control_logic.add_to(ctx);
-        ctx.instantiate::<InvChain>(&20)?
-            .with_connections([
-                ("din", decrepstart),
-                ("dout", decrepend),
-                ("vdd", vdd),
-                ("vss", vss),
-            ])
-            .named("decoder_replica")
-            .add_to(ctx);
 
         let col_sel_buf_b = ctx.bus("col_sel_buf_b", col_sel.width());
         let col_sel_buf = ctx.bus("col_sel_buf", col_sel.width());


### PR DESCRIPTION
- **control logic base layer layout**
- **control logic layout routing wip**
- **more control logic routing**
- **control logic layout routing wip**
- **move sr latch routing**
- **move sr latch routing**
- **move sr latch routing**
- **remove decoder replica ports from ctrl logic**
- **resolve rbl/rbl_b short**
- **resolve we/we_b short**
- **avoid and2_4 short**
- **swap cross coupled nand pins in sr latch**
- **use inv4 at end of inv chain**
- **adjust edge detector dout routing**
- **update edge detector**
- **special case wl ctl q**
- **place pin locations**
- **wrdrven routing fixes**
- **move decoder replica into control logic, remove from sram schematic**
